### PR TITLE
Feature/proveedores

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -111,3 +111,19 @@ jobs:
           TESTING: "1"
         run: |
           pytest -q
+
+  tests-complete:
+    name: All Tests Passed
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test matrix status
+        if: needs.test.result != 'success'
+        run: |
+          echo "One or more tests failed or were cancelled"
+          exit 1
+      
+      - name: Tests passed
+        run: |
+          echo "All tests completed successfully"

--- a/collection/Medisupply.postman_collection.json
+++ b/collection/Medisupply.postman_collection.json
@@ -14,46 +14,6 @@
 					"name": "proveedores",
 					"item": [
 						{
-							"name": "crear proveedor",
-							"protocolProfileBehavior": {
-								"followRedirects": true,
-								"disableUrlEncoding": false,
-								"disableCookies": false
-							},
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "User-Agent",
-										"value": "insomnia/11.6.1"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n\t\"nombre\": \"{% faker 'randomCompanyName' %}\",\n\t\"id_tributario\": \"20163456789\",\n\t\"tipo_proveedor\": \"Fabricante\",\n\t\"email\": \"{% faker 'randomEmail' %}\",\n\t\"pais\": \"Perú\",\n\t\"contacto1\": \"Juan Pérez - +51 999 888 777\",\n\t\"condiciones_entrega1\": \"Entrega en 5 días hábiles, cobertura nacional\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{ _.bff_web_url }}/proveedores",
-									"host": [
-										"{{ _.bff_web_url }}"
-									],
-									"path": [
-										"proveedores"
-									]
-								}
-							},
-							"response": []
-						},
-						{
 							"name": "health",
 							"protocolProfileBehavior": {
 								"followRedirects": true,
@@ -76,6 +36,73 @@
 									"path": [
 										"proveedores",
 										"health"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "crear proveedor",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"id_tributario = (Math.floor(Math.random() * 9e10) + 1e10).toString();",
+											"pm.collectionVariables.set(\"id_tributario\", id_tributario);"
+										],
+										"type": "text/javascript",
+										"packages": {},
+										"requests": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const response = pm.response.json();",
+											"const id = response.data?.id",
+											"pm.collectionVariables.set(\"id_proveedor\", id);"
+										],
+										"type": "text/javascript",
+										"packages": {},
+										"requests": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"followRedirects": true,
+								"disableUrlEncoding": false,
+								"disableCookies": false
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "User-Agent",
+										"value": "insomnia/11.6.1"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"id_tributario\": \"{{id_tributario}}\",\n\t\"tipo_proveedor\": \"Fabricante\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"pais\": \"Perú\",\n\t\"contacto1\": \"Juan Pérez - +51 999 888 777\",\n\t\"condiciones_entrega1\": \"Entrega en 5 días hábiles, cobertura nacional\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ _.bff_web_url }}/proveedores",
+									"host": [
+										"{{ _.bff_web_url }}"
+									],
+									"path": [
+										"proveedores"
 									]
 								}
 							},
@@ -124,7 +151,7 @@
 									}
 								],
 								"url": {
-									"raw": "{{ _.bff_web_url }}/proveedores/:id?=",
+									"raw": "{{ _.bff_web_url }}/proveedores/:id",
 									"host": [
 										"{{ _.bff_web_url }}"
 									],
@@ -132,16 +159,57 @@
 										"proveedores",
 										":id"
 									],
-									"query": [
+									"variable": [
 										{
-											"key": "",
-											"value": ""
+											"key": "id",
+											"value": "{{id_proveedor}}"
 										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "actualizar proveedor",
+							"protocolProfileBehavior": {
+								"followRedirects": true,
+								"disableUrlEncoding": false,
+								"disableCookies": false
+							},
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "User-Agent",
+										"value": "insomnia/11.6.1"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"id_tributario\": \"{{id_tributario}}\",\n\t\"tipo_proveedor\": \"Fabricante\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"pais\": \"Perú\",\n\t\"contacto\": \"Juan Pérez - +51 999 888 777\",\n\t\"condiciones_entrega\": \"Entrega en 5 días hábiles, cobertura nacional\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ _.bff_web_url }}/proveedores/:id",
+									"host": [
+										"{{ _.bff_web_url }}"
+									],
+									"path": [
+										"proveedores",
+										":id"
 									],
 									"variable": [
 										{
 											"key": "id",
-											"value": "{% response 'body', 'req_abd2bbabbd6b4dd9919f61916dc3d817', 'b64::JC5kYXRhWzBdLmlk::46b', 'no-history', 60 %}"
+											"value": "{{id_proveedor}}"
 										}
 									]
 								}
@@ -175,54 +243,7 @@
 									"variable": [
 										{
 											"key": "id",
-											"value": "{% response 'body', 'req_abd2bbabbd6b4dd9919f61916dc3d817', 'b64::JC5kYXRhWzBdLmlk::46b', 'always', 60 %}"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "actualizar proveedor",
-							"protocolProfileBehavior": {
-								"followRedirects": true,
-								"disableUrlEncoding": false,
-								"disableCookies": false
-							},
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "User-Agent",
-										"value": "insomnia/11.6.1"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n\t\"nombre\": \"{% faker 'randomCompanyName' %}\",\n\t\"id_tributario\": \"20143456789\",\n\t\"tipo_proveedor\": \"Fabricante\",\n\t\"email\": \"{% faker 'randomEmail' %}\",\n\t\"pais\": \"Perú\",\n\t\"contacto\": \"Juan Pérez - +51 999 888 777\",\n\t\"condiciones_entrega\": \"Entrega en 5 días hábiles, cobertura nacional\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{ _.bff_web_url }}/proveedores/:id",
-									"host": [
-										"{{ _.bff_web_url }}"
-									],
-									"path": [
-										"proveedores",
-										":id"
-									],
-									"variable": [
-										{
-											"key": "id",
-											"value": "{% response 'body', 'req_abd2bbabbd6b4dd9919f61916dc3d817', 'b64::JC5kYXRhWzBdLmlk::46b', 'no-history', 60 %}"
+											"value": "{{id_proveedor}}"
 										}
 									]
 								}
@@ -1179,6 +1200,33 @@
 				},
 				{
 					"name": "crear proveedor",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"id_tributario = (Math.floor(Math.random() * 9e10) + 1e10).toString();",
+									"pm.collectionVariables.set(\"id_tributario\", id_tributario);"
+								],
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const response = pm.response.json();",
+									"const id = response.data?.id",
+									"pm.collectionVariables.set(\"id_proveedor\", id);"
+								],
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
+							}
+						}
+					],
 					"protocolProfileBehavior": {
 						"followRedirects": true,
 						"disableUrlEncoding": false,
@@ -1198,7 +1246,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"nombre\": \"{% faker 'randomCompanyName' %}\",\n\t\"id_tributario\": \"20153456789\",\n\t\"tipo_proveedor\": \"Fabricante\",\n\t\"email\": \"{% faker 'randomEmail' %}\",\n\t\"pais\": \"Perú\",\n\t\"contacto1\": \"Juan Pérez - +51 999 888 777\",\n\t\"condiciones_entrega1\": \"Entrega en 5 días hábiles, cobertura nacional\"\n}",
+							"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"id_tributario\": \"{{id_tributario}}\",\n\t\"tipo_proveedor\": \"Fabricante\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"pais\": \"Perú\",\n\t\"contacto1\": \"Juan Pérez - +51 999 888 777\",\n\t\"condiciones_entrega1\": \"Entrega en 5 días hábiles, cobertura nacional\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1260,7 +1308,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{ _.proveedores_url }}/proveedores/:id?=",
+							"raw": "{{ _.proveedores_url }}/proveedores/:id",
 							"host": [
 								"{{ _.proveedores_url }}"
 							],
@@ -1268,16 +1316,10 @@
 								"proveedores",
 								":id"
 							],
-							"query": [
-								{
-									"key": "",
-									"value": ""
-								}
-							],
 							"variable": [
 								{
 									"key": "id",
-									"value": "{% response 'body', 'req_abd2bbabbd6b4dd9919f61916dc3d817', 'b64::JC5kYXRhWzBdLmlk::46b', 'no-history', 60 %}"
+									"value": "{{id_proveedor}}"
 								}
 							]
 						}
@@ -1305,7 +1347,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"nombre\": \"{% faker 'randomCompanyName' %}\",\n\t\"id_tributario\": \"20143456789\",\n\t\"tipo_proveedor\": \"Fabricante\",\n\t\"email\": \"{% faker 'randomEmail' %}\",\n\t\"pais\": \"Perú\",\n\t\"contacto\": \"Juan Pérez - +51 999 888 777\",\n\t\"condiciones_entrega\": \"Entrega en 5 días hábiles, cobertura nacional\"\n}",
+							"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"id_tributario\": \"{{id_tributario}}\",\n\t\"tipo_proveedor\": \"Fabricante\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"pais\": \"Perú\",\n\t\"contacto\": \"Juan Pérez - +51 999 888 777\",\n\t\"condiciones_entrega\": \"Entrega en 5 días hábiles, cobertura nacional\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1324,7 +1366,7 @@
 							"variable": [
 								{
 									"key": "id",
-									"value": "{% response 'body', 'req_abd2bbabbd6b4dd9919f61916dc3d817', 'b64::JC5kYXRhWzBdLmlk::46b', 'no-history', 60 %}"
+									"value": "{{id_proveedor}}"
 								}
 							]
 						}
@@ -1358,7 +1400,7 @@
 							"variable": [
 								{
 									"key": "id",
-									"value": "{% response 'body', 'req_abd2bbabbd6b4dd9919f61916dc3d817', 'b64::JC5kYXRhWzBdLmlk::46b', 'always', 60 %}"
+									"value": "{{id_proveedor}}"
 								}
 							]
 						}
@@ -1667,6 +1709,14 @@
 			"key": " _.autenticacion_url ",
 			"value": "",
 			"type": "default"
+		},
+		{
+			"key": "id_tributario",
+			"value": ""
+		},
+		{
+			"key": "id_proveedor",
+			"value": ""
 		}
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -354,18 +354,6 @@ services:
       - ./src/bff-web:/app
     networks:
       - medisupply-network
-    depends_on:
-      - auditoria-service
-      - autenticacion-service
-      - clientes-service
-      - inventario-service
-      - logistica-service
-      - order-command-api
-      - order-query-api
-      - productos-service
-      - proveedores-service
-      - reportes-service
-      - ventas-service
     
   bff-movil:
     profiles: [ "bff-movil", "ordenes", "autenticacion", "clientes", "dev" ]
@@ -390,11 +378,6 @@ services:
       - ./src/bff-movil:/app
     networks:
       - medisupply-network
-    depends_on:
-      - autenticacion-service
-      - clientes-service
-      - order-command-api
-      - order-query-api
 
 networks:
   medisupply-network:

--- a/src/bff-web/main.py
+++ b/src/bff-web/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from services.health_service import HealthService, get_health_service
 from router.auditoria import auditoria_router
 from router.autenticacion import autenticacion_router
@@ -22,6 +23,16 @@ app = FastAPI(
     version="1.0.0",
     docs_url="/docs",
     redoc_url="/redoc"
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:4200",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(auditoria_router, prefix="/auditoria", tags=["auditoria"])

--- a/src/bff-web/router/proveedores.py
+++ b/src/bff-web/router/proveedores.py
@@ -1,16 +1,197 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query, status
+from typing import Optional
 import logging
 
 from services.proveedores_service import ProveedoresService, get_proveedores_service
-
+from schemas.proveedor_schema import (
+    CrearProveedorSchema,
+    ActualizarProveedorSchema,
+    PaisEnum,
+    TipoProveedorEnum
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 proveedor_router = APIRouter()
-
-
-
 @proveedor_router.get("/health")
 def health_check(proveedores_service: ProveedoresService = Depends(get_proveedores_service)):
     return proveedores_service.health_check()
+
+@proveedor_router.post(
+    "/",
+    response_model=dict,
+    status_code=status.HTTP_201_CREATED,
+    summary="Crear nuevo proveedor",
+    description="Crea un nuevo proveedor en el sistema con validaciones de ID tributario y email únicos",
+    responses={
+        201: {
+            "description": "Proveedor creado exitosamente",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "message": "Creación exitosa",
+                        "data": {
+                            "id": "550e8400-e29b-41d4-a716-446655440000",
+                            "nombre": "Farmacéutica Nacional S.A.",
+                            "id_tributario": "20123456789",
+                            "email": "contacto@farmaceutica.com"
+                        }
+                    }
+                }
+            }
+        },
+        409: {"description": "ID tributario o email ya existe"},
+        422: {"description": "Error de validación en los datos"}
+    }
+)
+async def crear_proveedor(
+    proveedor: CrearProveedorSchema,
+    proveedores_service: ProveedoresService = Depends(get_proveedores_service)
+):
+    """
+    Crea un nuevo proveedor con los siguientes datos:
+    
+    - **nombre**: Nombre del proveedor (máximo 255 caracteres, obligatorio)
+    - **id_tributario**: RUC/NIT/RFC según país (único, obligatorio)
+    - **tipo_proveedor**: Tipo de proveedor (obligatorio)
+    - **email**: Email válido (único, obligatorio)
+    - **pais**: País de operación (obligatorio)
+    - **contacto**: Información de contacto (opcional, máximo 255 caracteres)
+    - **condiciones_entrega**: Condiciones de entrega (opcional, máximo 500 caracteres)
+    """
+    data = await proveedores_service.crear_proveedor(proveedor.model_dump())
+    return data
+
+
+@proveedor_router.get(
+    "/",
+    response_model=dict,
+    summary="Listar proveedores",
+    description="Obtiene listado de proveedores con filtros opcionales y paginación",
+    responses={
+        200: {
+            "description": "Lista de proveedores obtenida exitosamente",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "data": [
+                            {
+                                "id": "550e8400-e29b-41d4-a716-446655440000",
+                                "nombre": "Farmacéutica Nacional S.A.",
+                                "id_tributario": "20123456789",
+                                "tipo_proveedor": "Fabricante",
+                                "email": "contacto@farmaceutica.com",
+                                "pais": "Perú"
+                            }
+                        ],
+                        "total": 1,
+                        "page": 1,
+                        "page_size": 20
+                    }
+                }
+            }
+        }
+    }
+)
+async def listar_proveedores(
+    pais: Optional[PaisEnum] = Query(None, description="Filtrar por país"),
+    tipo_proveedor: Optional[TipoProveedorEnum] = Query(None, description="Filtrar por tipo de proveedor"),
+    page: int = Query(1, ge=1, description="Número de página"),
+    page_size: int = Query(20, ge=1, le=100, description="Tamaño de página (máximo 100)"),
+    proveedores_service: ProveedoresService = Depends(get_proveedores_service)
+):
+    """
+    Lista todos los proveedores con opciones de:
+    
+    - **Filtros**: Por país y tipo de proveedor
+    - **Paginación**: Con page (número de página) y page_size (tamaño)
+    - **Ordenamiento**: Por fecha de creación (más recientes primero)
+    """
+    pais_value = pais.value if pais else None
+    tipo_value = tipo_proveedor.value if tipo_proveedor else None
+    
+    data = await proveedores_service.listar_proveedores(
+        pais=pais_value,
+        tipo_proveedor=tipo_value,
+        page=page,
+        page_size=page_size
+    )
+    
+    return data
+
+
+@proveedor_router.get(
+    "/{proveedor_id}",
+    response_model=dict,
+    summary="Obtener proveedor por ID",
+    description="Obtiene los detalles completos de un proveedor específico",
+    responses={
+        200: {"description": "Proveedor encontrado"},
+        404: {"description": "Proveedor no encontrado"}
+    }
+)
+async def obtener_proveedor(
+    proveedor_id: str,
+    proveedores_service: ProveedoresService = Depends(get_proveedores_service)
+):
+    """
+    Obtiene toda la información de un proveedor específico por su ID.
+    """
+    data = await proveedores_service.obtener_proveedor(proveedor_id)
+    return data
+
+
+@proveedor_router.put(
+    "/{proveedor_id}",
+    response_model=dict,
+    summary="Actualizar proveedor",
+    description="Actualiza los datos de un proveedor existente",
+    responses={
+        200: {"description": "Proveedor actualizado exitosamente"},
+        404: {"description": "Proveedor no encontrado"},
+        409: {"description": "Email ya existe en otro proveedor"},
+        422: {"description": "Error de validación en los datos"}
+    }
+)
+async def actualizar_proveedor(
+    proveedor_id: str,
+    proveedor: ActualizarProveedorSchema,
+    proveedores_service: ProveedoresService = Depends(get_proveedores_service)
+):
+    """
+    Actualiza un proveedor existente.
+    
+    - Solo se actualizan los campos que se envíen en el request
+    - No se puede cambiar el ID tributario ni el país
+    - El email debe ser único si se actualiza
+    """
+    data = await proveedores_service.actualizar_proveedor(
+        proveedor_id,
+        proveedor.model_dump(exclude_unset=True)
+    )
+    return data
+
+
+@proveedor_router.delete(
+    "/{proveedor_id}",
+    response_model=dict,
+    status_code=status.HTTP_200_OK,
+    summary="Eliminar proveedor",
+    description="Elimina un proveedor del sistema",
+    responses={
+        200: {"description": "Proveedor eliminado exitosamente"},
+        404: {"description": "Proveedor no encontrado"}
+    }
+)
+async def eliminar_proveedor(
+    proveedor_id: str,
+    proveedores_service: ProveedoresService = Depends(get_proveedores_service)
+):
+    """
+    Elimina un proveedor del sistema.
+    
+    **Precaución**: Esta operación no se puede deshacer.
+    """
+    result = await proveedores_service.eliminar_proveedor(proveedor_id)
+    return result

--- a/src/bff-web/schemas/proveedor_schema.py
+++ b/src/bff-web/schemas/proveedor_schema.py
@@ -1,0 +1,155 @@
+from pydantic import Field, BaseModel, EmailStr, field_validator, model_validator
+from datetime import datetime
+from typing import Optional
+from enum import Enum
+import re
+
+
+class PaisEnum(str, Enum):
+    COLOMBIA = "Colombia"
+    PERU = "Perú"
+    ECUADOR = "Ecuador"
+    MEXICO = "México"
+
+
+class TipoProveedorEnum(str, Enum):
+    FABRICANTE = "Fabricante"
+    DISTRIBUIDOR = "Distribuidor"
+    MAYORISTA = "Mayorista"
+    IMPORTADOR = "Importador"
+    MINORISTA = "Minorista"
+
+
+class CrearProveedorSchema(BaseModel):
+    nombre: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Nombre del proveedor"
+    )
+    id_tributario: str = Field(
+        ...,
+        min_length=1,
+        description="ID tributario del proveedor (RUC/NIT/RFC según país)"
+    )
+    tipo_proveedor: TipoProveedorEnum = Field(
+        ...,
+        description="Tipo de proveedor"
+    )
+    email: EmailStr = Field(
+        ...,
+        description="Email del proveedor"
+    )
+    pais: PaisEnum = Field(
+        ...,
+        description="País del proveedor"
+    )
+    contacto: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="Contacto del proveedor"
+    )
+    condiciones_entrega: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Condiciones de entrega. Ej. Entrega en 5 días hábiles, cobertura nacional"
+    )
+
+    @model_validator(mode='after')
+    def validate_id_tributario(self):
+        """
+        Valida el formato del ID tributario según el país:
+        - RUC (Perú): 11 dígitos
+        - NIT (Colombia): 9-10 dígitos
+        - RFC (México): 12-13 caracteres alfanuméricos
+        """
+        id_trib = self.id_tributario.strip()
+        pais = self.pais
+        
+        if pais == PaisEnum.PERU:
+            # RUC: 11 dígitos
+            if not re.match(r'^\d{11}$', id_trib):
+                raise ValueError('RUC debe tener 11 dígitos numéricos')
+        elif pais == PaisEnum.COLOMBIA:
+            # NIT: 9-10 dígitos
+            if not re.match(r'^\d{9,10}$', id_trib):
+                raise ValueError('NIT debe tener 9 o 10 dígitos numéricos')
+        elif pais == PaisEnum.MEXICO:
+            # RFC: 12-13 caracteres alfanuméricos
+            if not re.match(r'^[A-ZÑ&]{3,4}\d{6}[A-Z0-9]{3}$', id_trib.upper()):
+                raise ValueError('RFC debe tener formato válido (12-13 caracteres alfanuméricos)')
+            self.id_tributario = id_trib.upper()
+        elif pais == PaisEnum.ECUADOR:
+            # RUC Ecuador: 13 dígitos
+            if not re.match(r'^\d{13}$', id_trib):
+                raise ValueError('RUC debe tener 13 dígitos numéricos')
+        
+        # Update with trimmed value
+        self.id_tributario = id_trib
+        return self
+
+    @field_validator('nombre', 'contacto')
+    @classmethod
+    def validate_no_empty_strings(cls, v: Optional[str]) -> Optional[str]:
+        """Valida que los campos de texto no sean strings vacíos"""
+        if v is not None and v.strip() == '':
+            raise ValueError('El campo no puede estar vacío')
+        return v.strip() if v else v
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "nombre": "Farmacéutica Nacional S.A.",
+                "id_tributario": "20123456789",
+                "tipo_proveedor": "Fabricante",
+                "email": "contacto@farmaceutica.com",
+                "pais": "Perú",
+                "contacto": "Juan Pérez - +51 999 888 777",
+                "condiciones_entrega": "Entrega en 5 días hábiles, cobertura nacional"
+            }
+        }
+
+
+class ActualizarProveedorSchema(BaseModel):
+    nombre: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=255,
+        description="Nombre del proveedor"
+    )
+    tipo_proveedor: Optional[TipoProveedorEnum] = Field(
+        None,
+        description="Tipo de proveedor"
+    )
+    email: Optional[EmailStr] = Field(
+        None,
+        description="Email del proveedor"
+    )
+    contacto: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="Contacto del proveedor"
+    )
+    condiciones_entrega: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Condiciones de entrega"
+    )
+
+    @field_validator('nombre', 'contacto')
+    @classmethod
+    def validate_no_empty_strings(cls, v: Optional[str]) -> Optional[str]:
+        """Valida que los campos de texto no sean strings vacíos"""
+        if v is not None and v.strip() == '':
+            raise ValueError('El campo no puede estar vacío')
+        return v.strip() if v else v
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "nombre": "Farmacéutica Nacional S.A.C.",
+                "email": "nuevo@farmaceutica.com",
+                "contacto": "María García - +51 999 777 888"
+            }
+        }
+

--- a/src/bff-web/services/proveedores_service.py
+++ b/src/bff-web/services/proveedores_service.py
@@ -1,6 +1,6 @@
 import httpx
 import os
-from typing import Dict, Any
+from typing import Optional, Dict, Any
 from fastapi import HTTPException
 import logging
 
@@ -13,7 +13,7 @@ class ProveedoresService:
     def __init__(self):
         self.base_url = os.getenv("PROVEEDORES_SERVICE_URL", "http://proveedores-service:3000")
         self.timeout = 30.0
-    
+
     def health_check(self) -> Dict[str, Any]:
         """Check the health of the Proveedores microservice"""
         try:
@@ -29,6 +29,153 @@ class ProveedoresService:
         except Exception as e:
             logger.error(f"Unexpected error checking Proveedores health: {e}")
             raise HTTPException(status_code=500, detail=f"Unexpected error: {e}")
+
+    async def crear_proveedor(self, proveedor_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new proveedor via the proveedores service"""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{self.base_url}/proveedores/",
+                    json=proveedor_data
+                )
+                
+                if response.status_code == 201:
+                    return response.json()
+                elif response.status_code == 409:
+                    raise HTTPException(status_code=409, detail=response.json())
+                elif response.status_code == 422:
+                    raise HTTPException(status_code=422, detail=response.json())
+                else:
+                    raise HTTPException(
+                        status_code=response.status_code,
+                        detail=f"Error from proveedores service: {response.text}"
+                    )
+        except httpx.RequestError as e:
+            logger.error(f"Error connecting to proveedores service: {str(e)}")
+            raise HTTPException(
+                status_code=503,
+                detail="Proveedores service is not available"
+            )
+    
+    async def listar_proveedores(
+        self,
+        pais: Optional[str] = None,
+        tipo_proveedor: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20
+    ) -> Dict[str, Any]:
+        """List proveedores with optional filters"""
+        try:
+            params = {
+                "page": page,
+                "page_size": page_size
+            }
+            if pais:
+                params["pais"] = pais
+            if tipo_proveedor:
+                params["tipo_proveedor"] = tipo_proveedor
+            
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(
+                    f"{self.base_url}/proveedores/",
+                    params=params
+                )
+                
+                if response.status_code == 200:
+                    return response.json()
+                else:
+                    raise HTTPException(
+                        status_code=response.status_code,
+                        detail=f"Error from proveedores service: {response.text}"
+                    )
+        except httpx.RequestError as e:
+            logger.error(f"Error connecting to proveedores service: {str(e)}")
+            raise HTTPException(
+                status_code=503,
+                detail="Proveedores service is not available"
+            )
+    
+    async def obtener_proveedor(self, proveedor_id: str) -> Dict[str, Any]:
+        """Get a specific proveedor by ID"""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(
+                    f"{self.base_url}/proveedores/{proveedor_id}"
+                )
+                
+                if response.status_code == 200:
+                    return response.json()
+                elif response.status_code == 404:
+                    raise HTTPException(status_code=404, detail="Proveedor no encontrado")
+                else:
+                    raise HTTPException(
+                        status_code=response.status_code,
+                        detail=f"Error from proveedores service: {response.text}"
+                    )
+        except httpx.RequestError as e:
+            logger.error(f"Error connecting to proveedores service: {str(e)}")
+            raise HTTPException(
+                status_code=503,
+                detail="Proveedores service is not available"
+            )
+    
+    async def actualizar_proveedor(
+        self,
+        proveedor_id: str,
+        proveedor_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Update an existing proveedor"""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.put(
+                    f"{self.base_url}/proveedores/{proveedor_id}",
+                    json=proveedor_data
+                )
+                
+                if response.status_code == 200:
+                    return response.json()
+                elif response.status_code == 404:
+                    raise HTTPException(status_code=404, detail="Proveedor no encontrado")
+                elif response.status_code == 409:
+                    raise HTTPException(status_code=409, detail=response.json())
+                elif response.status_code == 422:
+                    raise HTTPException(status_code=422, detail=response.json())
+                else:
+                    raise HTTPException(
+                        status_code=response.status_code,
+                        detail=f"Error from proveedores service: {response.text}"
+                    )
+        except httpx.RequestError as e:
+            logger.error(f"Error connecting to proveedores service: {str(e)}")
+            raise HTTPException(
+                status_code=503,
+                detail="Proveedores service is not available"
+            )
+    
+    async def eliminar_proveedor(self, proveedor_id: str) -> Dict[str, Any]:
+        """Delete a proveedor"""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.delete(
+                    f"{self.base_url}/proveedores/{proveedor_id}"
+                )
+                
+                if response.status_code == 200:
+                    return response.json()
+                elif response.status_code == 404:
+                    raise HTTPException(status_code=404, detail="Proveedor no encontrado")
+                else:
+                    raise HTTPException(
+                        status_code=response.status_code,
+                        detail=f"Error from proveedores service: {response.text}"
+                    )
+        except httpx.RequestError as e:
+            logger.error(f"Error connecting to proveedores service: {str(e)}")
+            raise HTTPException(
+                status_code=503,
+                detail="Proveedores service is not available"
+            )
+
 
 def get_proveedores_service() -> ProveedoresService:
     """Dependency function to get proveedores service instance"""

--- a/src/proveedores/README.md
+++ b/src/proveedores/README.md
@@ -1,0 +1,285 @@
+# Módulo de Gestión de Proveedores - MediSupply
+
+## 📋 Descripción
+
+Este módulo implementa la funcionalidad completa de gestión de proveedores para MediSupply, permitiendo el registro, actualización, consulta y eliminación de proveedores según los requerimientos de la historia de usuario.
+
+## 🏗️ Arquitectura
+
+### Estructura de Archivos
+
+```
+src/proveedores/
+├── db/
+│   ├── database.py           # Configuración de base de datos
+│   └── proveedor_model.py    # Modelo SQLAlchemy
+├── schemas/
+│   └── proveedor_schema.py   # Schemas Pydantic para validación
+├── services/
+│   ├── proveedor_service.py  # Lógica de negocio
+│   └── health_service.py     # Servicio de salud
+├── router/
+│   └── proveedor_router.py   # Endpoints REST API
+└── main.py                    # Aplicación FastAPI
+```
+
+## 📊 Modelo de Datos
+
+### Tabla: `proveedores`
+
+| Campo | Tipo | Restricciones | Descripción |
+|-------|------|---------------|-------------|
+| `id` | UUID | Primary Key | Identificador único |
+| `fecha_creacion` | DateTime | Not Null | Fecha de creación |
+| `fecha_actualizacion` | DateTime | Not Null | Fecha de última actualización |
+| `nombre` | String(255) | Not Null | Nombre del proveedor |
+| `id_tributario` | String | Not Null, Unique | RUC/NIT/RFC según país |
+| `tipo_proveedor` | String | Not Null | Tipo de proveedor |
+| `email` | String | Not Null, Unique | Email del proveedor |
+| `pais` | String | Not Null | País de operación |
+| `contacto` | String(255) | Nullable | Información de contacto |
+| `condiciones_entrega` | String(500) | Nullable | Condiciones de entrega |
+
+## 🔐 Validaciones Implementadas
+
+### 1. **Validación de ID Tributario por País**
+
+- **Perú (RUC)**: 11 dígitos numéricos
+- **Colombia (NIT)**: 9-10 dígitos numéricos
+- **México (RFC)**: 12-13 caracteres alfanuméricos con formato específico
+- **Ecuador (RUC)**: 13 dígitos numéricos
+
+### 2. **Validación de Email**
+
+- Formato válido de email usando `EmailStr` de Pydantic
+- Unicidad en el sistema
+
+### 3. **Validación de Campos Obligatorios**
+
+- `nombre`: 1-255 caracteres
+- `id_tributario`: Único y con formato válido
+- `tipo_proveedor`: Valor de enum predefinido
+- `email`: Formato válido y único
+- `pais`: Valor de enum predefinido
+
+### 4. **Validación de Longitudes**
+
+- `nombre`: Máximo 255 caracteres
+- `contacto`: Máximo 255 caracteres
+- `condiciones_entrega`: Máximo 500 caracteres
+
+## 🎯 Endpoints API
+
+### Base URL: `/proveedores`
+
+#### 1. **Crear Proveedor**
+```http
+POST /proveedores/
+```
+
+**Request Body:**
+```json
+{
+  "nombre": "Farmacéutica Nacional S.A.",
+  "id_tributario": "20123456789",
+  "tipo_proveedor": "Fabricante",
+  "email": "contacto@farmaceutica.com",
+  "pais": "Perú",
+  "contacto": "Juan Pérez - +51 999 888 777",
+  "condiciones_entrega": "Entrega en 5 días hábiles, cobertura nacional"
+}
+```
+
+**Response (201):**
+```json
+{
+  "message": "Creación exitosa",
+  "data": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "nombre": "Farmacéutica Nacional S.A.",
+    "id_tributario": "20123456789",
+    ...
+  }
+}
+```
+
+**Errores:**
+- `409`: ID tributario o email ya existe
+- `422`: Error de validación en los datos
+
+---
+
+#### 2. **Listar Proveedores**
+```http
+GET /proveedores/?page=1&page_size=20&pais=Perú&tipo_proveedor=Fabricante
+```
+
+**Query Parameters:**
+- `page`: Número de página (default: 1)
+- `page_size`: Tamaño de página (default: 20, max: 100)
+- `pais`: Filtrar por país (opcional)
+- `tipo_proveedor`: Filtrar por tipo (opcional)
+
+**Response (200):**
+```json
+{
+  "data": [...],
+  "total": 50,
+  "page": 1,
+  "page_size": 20,
+  "total_pages": 3
+}
+```
+
+---
+
+#### 3. **Obtener Proveedor por ID**
+```http
+GET /proveedores/{proveedor_id}
+```
+
+**Response (200):**
+```json
+{
+  "data": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "nombre": "Farmacéutica Nacional S.A.",
+    ...
+  }
+}
+```
+
+**Errores:**
+- `404`: Proveedor no encontrado
+
+---
+
+#### 4. **Actualizar Proveedor**
+```http
+PUT /proveedores/{proveedor_id}
+```
+
+**Request Body (campos opcionales):**
+```json
+{
+  "nombre": "Farmacéutica Nacional S.A.C.",
+  "email": "nuevo@farmaceutica.com",
+  "contacto": "María García - +51 999 777 888"
+}
+```
+
+**Response (200):**
+```json
+{
+  "message": "Proveedor actualizado exitosamente",
+  "data": {...}
+}
+```
+
+**Errores:**
+- `404`: Proveedor no encontrado
+- `409`: Email ya existe en otro proveedor
+- `422`: Error de validación
+
+---
+
+#### 5. **Eliminar Proveedor**
+```http
+DELETE /proveedores/{proveedor_id}
+```
+
+**Response (200):**
+```json
+{
+  "message": "Proveedor eliminado exitosamente"
+}
+```
+
+**Errores:**
+- `404`: Proveedor no encontrado
+
+---
+
+## 📝 Enumeraciones
+
+### TipoProveedorEnum
+- `Fabricante`
+- `Distribuidor`
+- `Mayorista`
+- `Importador`
+- `Minorista`
+
+### PaisEnum
+- `Colombia`
+- `Perú`
+- `Ecuador`
+- `México`
+
+### Acceder a la Documentación
+- Swagger UI: http://localhost:8000/docs
+- ReDoc: http://localhost:8000/redoc
+
+## 🔧 Testing
+
+### Crear un Proveedor de Prueba
+
+```bash
+curl -X POST "http://localhost:8000/proveedores/" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "nombre": "Test Farmacéutica",
+    "id_tributario": "20123456789",
+    "tipo_proveedor": "Fabricante",
+    "email": "test@test.com",
+    "pais": "Perú",
+    "contacto": "Test Contact",
+    "condiciones_entrega": "Test conditions"
+  }'
+```
+
+### Listar Proveedores
+
+```bash
+curl "http://localhost:8000/proveedores/?page=1&page_size=10"
+```
+
+## 📊 Estructura de Respuestas
+
+### Respuesta Exitosa
+```json
+{
+  "message": "string",
+  "data": {...}
+}
+```
+
+### Respuesta de Error
+```json
+{
+  "detail": "Mensaje de error descriptivo"
+}
+```
+
+## 🎨 Características Adicionales
+
+### Paginación
+- Soporte para paginación en listado de proveedores
+- Control de tamaño de página (máximo 100 registros)
+- Información de totales y páginas disponibles
+
+### Filtros
+- Filtrar por país
+- Filtrar por tipo de proveedor
+- Combinación de filtros
+
+### Ordenamiento
+- Proveedores ordenados por fecha de creación (más recientes primero)
+
+## 📝 Notas Importantes
+
+- Los campos `id_tributario` y `pais` NO se pueden modificar después de la creación
+- El email debe ser único en todo el sistema
+- Los ID tributarios se validan automáticamente según el país
+- Las fechas se manejan en UTC para consistencia
+- La base de datos se inicializa automáticamente al iniciar el servicio
+

--- a/src/proveedores/db/proveedor_model.py
+++ b/src/proveedores/db/proveedor_model.py
@@ -1,0 +1,47 @@
+from sqlalchemy import Column, DateTime, String
+from sqlalchemy.dialects.postgresql import UUID
+from datetime import datetime, timezone
+import uuid
+from .database import Base
+
+
+class Proveedor(Base):
+    __tablename__ = "proveedores"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    fecha_creacion = Column(DateTime, default=datetime.now())
+    fecha_actualizacion = Column(DateTime, default=datetime.now())
+    nombre = Column(String(255), nullable=False)
+    id_tributario = Column(String, nullable=False, unique=True)
+    tipo_proveedor = Column(String, nullable=False)
+    email = Column(String, nullable=False, unique=True)
+    pais = Column(String, nullable=False)
+    contacto = Column(String(255), nullable=True)
+    condiciones_entrega = Column(String(500), nullable=True)
+
+    def __init__(self, nombre, id_tributario, tipo_proveedor, email, pais, contacto=None, condiciones_entrega=None):
+        now = datetime.now(timezone.utc)
+        self.fecha_creacion = now
+        self.fecha_actualizacion = now
+        self.nombre = nombre
+        self.id_tributario = id_tributario
+        self.tipo_proveedor = tipo_proveedor
+        self.email = email
+        self.pais = pais
+        self.contacto = contacto
+        self.condiciones_entrega = condiciones_entrega
+
+    def to_dict(self):
+        """Convert Proveedor instance to dictionary"""
+        return {
+            "id": str(self.id),
+            "fecha_creacion": self.fecha_creacion.isoformat() if self.fecha_creacion else None,
+            "fecha_actualizacion": self.fecha_actualizacion.isoformat() if self.fecha_actualizacion else None,
+            "nombre": self.nombre,
+            "id_tributario": self.id_tributario,
+            "tipo_proveedor": self.tipo_proveedor,
+            "email": self.email,
+            "pais": self.pais,
+            "contacto": self.contacto,
+            "condiciones_entrega": self.condiciones_entrega,
+        }

--- a/src/proveedores/db/proveedor_model.py
+++ b/src/proveedores/db/proveedor_model.py
@@ -9,8 +9,8 @@ class Proveedor(Base):
     __tablename__ = "proveedores"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    fecha_creacion = Column(DateTime, default=datetime.now())
-    fecha_actualizacion = Column(DateTime, default=datetime.now())
+    fecha_creacion = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    fecha_actualizacion = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     nombre = Column(String(255), nullable=False)
     id_tributario = Column(String, nullable=False, unique=True)
     tipo_proveedor = Column(String, nullable=False)

--- a/src/proveedores/main.py
+++ b/src/proveedores/main.py
@@ -5,7 +5,7 @@ from db.database import engine, Base
 from db.proveedor_model import Proveedor  # Import model to ensure it's registered with Base
 import logging
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG, force=True)
 logger = logging.getLogger(__name__)
 
 app = FastAPI(

--- a/src/proveedores/main.py
+++ b/src/proveedores/main.py
@@ -1,7 +1,29 @@
 from fastapi import FastAPI, Depends, HTTPException
 from services.health_service import HealthService, get_health_service
+from router.proveedor_router import proveedor_router
+from db.database import engine, Base
+from db.proveedor_model import Proveedor  # Import model to ensure it's registered with Base
+import logging
 
-app = FastAPI()
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="MediSupply - Proveedores Service",
+    description="API para la gestión de proveedores en MediSupply",
+    version="1.0.0",
+    docs_url="/docs",
+    redoc_url="/redoc"
+)
+
+Base.metadata.create_all(bind=engine)
+logger.info("Database tables created successfully")
+
+app.include_router(
+    proveedor_router,
+    prefix="/proveedores",
+    tags=["Proveedores"]
+)
 
 
 @app.get("/health")

--- a/src/proveedores/router/proveedor_router.py
+++ b/src/proveedores/router/proveedor_router.py
@@ -1,0 +1,214 @@
+from fastapi import APIRouter, Depends, Query, status
+from typing import Optional
+import logging
+
+from services.proveedor_service import ProveedorService, get_proveedor_service
+from schemas.proveedor_schema import (
+    CrearProveedorSchema,
+    ActualizarProveedorSchema,
+    PaisEnum,
+    TipoProveedorEnum
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+proveedor_router = APIRouter()
+
+
+@proveedor_router.post(
+    "/",
+    response_model=dict,
+    status_code=status.HTTP_201_CREATED,
+    summary="Crear nuevo proveedor",
+    description="Crea un nuevo proveedor en el sistema con validaciones de ID tributario y email únicos",
+    responses={
+        201: {
+            "description": "Proveedor creado exitosamente",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "message": "Creación exitosa",
+                        "data": {
+                            "id": "550e8400-e29b-41d4-a716-446655440000",
+                            "nombre": "Farmacéutica Nacional S.A.",
+                            "id_tributario": "20123456789",
+                            "email": "contacto@farmaceutica.com"
+                        }
+                    }
+                }
+            }
+        },
+        409: {"description": "ID tributario o email ya existe"},
+        422: {"description": "Error de validación en los datos"}
+    }
+)
+async def crear_proveedor(
+    proveedor: CrearProveedorSchema,
+    proveedor_service: ProveedorService = Depends(get_proveedor_service)
+):
+    """
+    Crea un nuevo proveedor con los siguientes datos:
+    
+    - **nombre**: Nombre del proveedor (máximo 255 caracteres, obligatorio)
+    - **id_tributario**: RUC/NIT/RFC según país (único, obligatorio)
+    - **tipo_proveedor**: Tipo de proveedor (obligatorio)
+    - **email**: Email válido (único, obligatorio)
+    - **pais**: País de operación (obligatorio)
+    - **contacto**: Información de contacto (opcional, máximo 255 caracteres)
+    - **condiciones_entrega**: Condiciones de entrega (opcional, máximo 500 caracteres)
+    """
+    data = proveedor_service.crear_proveedor(proveedor)
+    return {
+        "message": "Creación exitosa",
+        "data": data
+    }
+
+
+@proveedor_router.get(
+    "/",
+    response_model=dict,
+    summary="Listar proveedores",
+    description="Obtiene listado de proveedores con filtros opcionales y paginación",
+    responses={
+        200: {
+            "description": "Lista de proveedores obtenida exitosamente",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "data": [
+                            {
+                                "id": "550e8400-e29b-41d4-a716-446655440000",
+                                "nombre": "Farmacéutica Nacional S.A.",
+                                "id_tributario": "20123456789",
+                                "tipo_proveedor": "Fabricante",
+                                "email": "contacto@farmaceutica.com",
+                                "pais": "Perú"
+                            }
+                        ],
+                        "total": 1,
+                        "page": 1,
+                        "page_size": 20
+                    }
+                }
+            }
+        }
+    }
+)
+async def listar_proveedores(
+    pais: Optional[PaisEnum] = Query(None, description="Filtrar por país"),
+    tipo_proveedor: Optional[TipoProveedorEnum] = Query(None, description="Filtrar por tipo de proveedor"),
+    page: int = Query(1, ge=1, description="Número de página"),
+    page_size: int = Query(20, ge=1, le=100, description="Tamaño de página (máximo 100)"),
+    proveedor_service: ProveedorService = Depends(get_proveedor_service)
+):
+    """
+    Lista todos los proveedores con opciones de:
+    
+    - **Filtros**: Por país y tipo de proveedor
+    - **Paginación**: Con page (número de página) y page_size (tamaño)
+    - **Ordenamiento**: Por fecha de creación (más recientes primero)
+    """
+    skip = (page - 1) * page_size
+    
+    pais_value = pais.value if pais else None
+    tipo_value = tipo_proveedor.value if tipo_proveedor else None
+    
+    proveedores = proveedor_service.listar_proveedores(
+        pais=pais_value,
+        tipo_proveedor=tipo_value,
+        skip=skip,
+        limit=page_size
+    )
+    
+    total = proveedor_service.contar_proveedores(
+        pais=pais_value,
+        tipo_proveedor=tipo_value
+    )
+    
+    return {
+        "data": proveedores,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "total_pages": (total + page_size - 1) // page_size if total > 0 else 0
+    }
+
+
+@proveedor_router.get(
+    "/{proveedor_id}",
+    response_model=dict,
+    summary="Obtener proveedor por ID",
+    description="Obtiene los detalles completos de un proveedor específico",
+    responses={
+        200: {"description": "Proveedor encontrado"},
+        404: {"description": "Proveedor no encontrado"}
+    }
+)
+async def obtener_proveedor(
+    proveedor_id: str,
+    proveedor_service: ProveedorService = Depends(get_proveedor_service)
+):
+    """
+    Obtiene toda la información de un proveedor específico por su ID.
+    """
+    data = proveedor_service.obtener_proveedor(proveedor_id)
+    return {
+        "data": data
+    }
+
+
+@proveedor_router.put(
+    "/{proveedor_id}",
+    response_model=dict,
+    summary="Actualizar proveedor",
+    description="Actualiza los datos de un proveedor existente",
+    responses={
+        200: {"description": "Proveedor actualizado exitosamente"},
+        404: {"description": "Proveedor no encontrado"},
+        409: {"description": "Email ya existe en otro proveedor"},
+        422: {"description": "Error de validación en los datos"}
+    }
+)
+async def actualizar_proveedor(
+    proveedor_id: str,
+    proveedor: ActualizarProveedorSchema,
+    proveedor_service: ProveedorService = Depends(get_proveedor_service)
+):
+    """
+    Actualiza un proveedor existente.
+    
+    - Solo se actualizan los campos que se envíen en el request
+    - No se puede cambiar el ID tributario ni el país
+    - El email debe ser único si se actualiza
+    """
+    data = proveedor_service.actualizar_proveedor(proveedor_id, proveedor)
+    return {
+        "message": "Proveedor actualizado exitosamente",
+        "data": data
+    }
+
+
+@proveedor_router.delete(
+    "/{proveedor_id}",
+    response_model=dict,
+    status_code=status.HTTP_200_OK,
+    summary="Eliminar proveedor",
+    description="Elimina un proveedor del sistema",
+    responses={
+        200: {"description": "Proveedor eliminado exitosamente"},
+        404: {"description": "Proveedor no encontrado"}
+    }
+)
+async def eliminar_proveedor(
+    proveedor_id: str,
+    proveedor_service: ProveedorService = Depends(get_proveedor_service)
+):
+    """
+    Elimina un proveedor del sistema.
+    
+    **Precaución**: Esta operación no se puede deshacer.
+    """
+    result = proveedor_service.eliminar_proveedor(proveedor_id)
+    return result
+

--- a/src/proveedores/schemas/proveedor_schema.py
+++ b/src/proveedores/schemas/proveedor_schema.py
@@ -1,0 +1,154 @@
+from pydantic import Field, BaseModel, EmailStr, field_validator, model_validator
+from datetime import datetime
+from typing import Optional
+from enum import Enum
+import re
+
+
+class PaisEnum(str, Enum):
+    COLOMBIA = "Colombia"
+    PERU = "Perú"
+    ECUADOR = "Ecuador"
+    MEXICO = "México"
+
+
+class TipoProveedorEnum(str, Enum):
+    FABRICANTE = "Fabricante"
+    DISTRIBUIDOR = "Distribuidor"
+    MAYORISTA = "Mayorista"
+    IMPORTADOR = "Importador"
+    MINORISTA = "Minorista"
+
+
+class CrearProveedorSchema(BaseModel):
+    nombre: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Nombre del proveedor"
+    )
+    id_tributario: str = Field(
+        ...,
+        min_length=1,
+        description="ID tributario del proveedor (RUC/NIT/RFC según país)"
+    )
+    tipo_proveedor: TipoProveedorEnum = Field(
+        ...,
+        description="Tipo de proveedor"
+    )
+    email: EmailStr = Field(
+        ...,
+        description="Email del proveedor"
+    )
+    pais: PaisEnum = Field(
+        ...,
+        description="País del proveedor"
+    )
+    contacto: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="Contacto del proveedor"
+    )
+    condiciones_entrega: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Condiciones de entrega. Ej. Entrega en 5 días hábiles, cobertura nacional"
+    )
+
+    @model_validator(mode='after')
+    def validate_id_tributario(self):
+        """
+        Valida el formato del ID tributario según el país:
+        - RUC (Perú): 11 dígitos
+        - NIT (Colombia): 9-10 dígitos
+        - RFC (México): 12-13 caracteres alfanuméricos
+        """
+        id_trib = self.id_tributario.strip()
+        pais = self.pais
+        
+        if pais == PaisEnum.PERU:
+            # RUC: 11 dígitos
+            if not re.match(r'^\d{11}$', id_trib):
+                raise ValueError('RUC debe tener 11 dígitos numéricos')
+        elif pais == PaisEnum.COLOMBIA:
+            # NIT: 9-10 dígitos
+            if not re.match(r'^\d{9,10}$', id_trib):
+                raise ValueError('NIT debe tener 9 o 10 dígitos numéricos')
+        elif pais == PaisEnum.MEXICO:
+            # RFC: 12-13 caracteres alfanuméricos
+            if not re.match(r'^[A-ZÑ&]{3,4}\d{6}[A-Z0-9]{3}$', id_trib.upper()):
+                raise ValueError('RFC debe tener formato válido (12-13 caracteres alfanuméricos)')
+            self.id_tributario = id_trib.upper()
+        elif pais == PaisEnum.ECUADOR:
+            # RUC Ecuador: 13 dígitos
+            if not re.match(r'^\d{13}$', id_trib):
+                raise ValueError('RUC debe tener 13 dígitos numéricos')
+        
+        # Update with trimmed value
+        self.id_tributario = id_trib
+        return self
+
+    @field_validator('nombre', 'contacto')
+    @classmethod
+    def validate_no_empty_strings(cls, v: Optional[str]) -> Optional[str]:
+        """Valida que los campos de texto no sean strings vacíos"""
+        if v is not None and v.strip() == '':
+            raise ValueError('El campo no puede estar vacío')
+        return v.strip() if v else v
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "nombre": "Farmacéutica Nacional S.A.",
+                "id_tributario": "20123456789",
+                "tipo_proveedor": "Fabricante",
+                "email": "contacto@farmaceutica.com",
+                "pais": "Perú",
+                "contacto": "Juan Pérez - +51 999 888 777",
+                "condiciones_entrega": "Entrega en 5 días hábiles, cobertura nacional"
+            }
+        }
+
+
+class ActualizarProveedorSchema(BaseModel):
+    nombre: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=255,
+        description="Nombre del proveedor"
+    )
+    tipo_proveedor: Optional[TipoProveedorEnum] = Field(
+        None,
+        description="Tipo de proveedor"
+    )
+    email: Optional[EmailStr] = Field(
+        None,
+        description="Email del proveedor"
+    )
+    contacto: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="Contacto del proveedor"
+    )
+    condiciones_entrega: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Condiciones de entrega"
+    )
+
+    @field_validator('nombre', 'contacto')
+    @classmethod
+    def validate_no_empty_strings(cls, v: Optional[str]) -> Optional[str]:
+        """Valida que los campos de texto no sean strings vacíos"""
+        if v is not None and v.strip() == '':
+            raise ValueError('El campo no puede estar vacío')
+        return v.strip() if v else v
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "nombre": "Farmacéutica Nacional S.A.C.",
+                "email": "nuevo@farmaceutica.com",
+                "contacto": "María García - +51 999 777 888"
+            }
+        }

--- a/src/proveedores/services/proveedor_service.py
+++ b/src/proveedores/services/proveedor_service.py
@@ -1,0 +1,329 @@
+from typing import Dict, Any, List, Optional
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from fastapi import Depends, HTTPException
+from http import HTTPStatus
+from datetime import datetime, timezone
+import logging
+
+from db.database import get_db
+from db.proveedor_model import Proveedor
+from schemas.proveedor_schema import (
+    CrearProveedorSchema,
+    ActualizarProveedorSchema,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ProveedorService:
+    def __init__(self, db: Session = Depends(get_db)):
+        self.db = db
+
+    def crear_proveedor(self, proveedor_data: CrearProveedorSchema) -> Dict[str, Any]:
+        """
+        Crea un nuevo proveedor en el sistema.
+        
+        Args:
+            proveedor_data: Datos del proveedor a crear
+            
+        Returns:
+            Dict con los datos del proveedor creado
+            
+        Raises:
+            HTTPException: Si el id_tributario o email ya existen
+        """
+        try:
+            # Verificar si el id_tributario ya existe
+            existing_by_id_tributario = self.db.query(Proveedor).filter(
+                Proveedor.id_tributario == proveedor_data.id_tributario
+            ).first()
+            
+            if existing_by_id_tributario:
+                raise HTTPException(
+                    status_code=HTTPStatus.CONFLICT,
+                    detail=f"El ID tributario {proveedor_data.id_tributario} ya está registrado en el sistema."
+                )
+            
+            # Verificar si el email ya existe
+            existing_by_email = self.db.query(Proveedor).filter(
+                Proveedor.email == proveedor_data.email
+            ).first()
+            
+            if existing_by_email:
+                raise HTTPException(
+                    status_code=HTTPStatus.CONFLICT,
+                    detail=f"El email {proveedor_data.email} ya está registrado en el sistema."
+                )
+            
+            nuevo_proveedor = Proveedor(
+                nombre=proveedor_data.nombre,
+                id_tributario=proveedor_data.id_tributario,
+                tipo_proveedor=proveedor_data.tipo_proveedor.value,
+                email=proveedor_data.email,
+                pais=proveedor_data.pais.value,
+                contacto=proveedor_data.contacto,
+                condiciones_entrega=proveedor_data.condiciones_entrega
+            )
+            
+            self.db.add(nuevo_proveedor)
+            self.db.commit()
+            self.db.refresh(nuevo_proveedor)
+            
+            logger.info(f"Proveedor creado exitosamente: {nuevo_proveedor.id}")
+            
+            return nuevo_proveedor.to_dict()
+            
+        except HTTPException:
+            raise
+        except IntegrityError as e:
+            self.db.rollback()
+            logger.error(f"Error de integridad al crear proveedor: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.CONFLICT,
+                detail="El ID tributario o email ya existe en el sistema."
+            )
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Error al crear proveedor: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al crear el proveedor."
+            )
+
+    def obtener_proveedor(self, proveedor_id: str) -> Dict[str, Any]:
+        """
+        Obtiene un proveedor por su ID.
+        
+        Args:
+            proveedor_id: ID del proveedor
+            
+        Returns:
+            Dict con los datos del proveedor
+            
+        Raises:
+            HTTPException: Si el proveedor no existe
+        """
+        try:
+            proveedor = self.db.query(Proveedor).filter(
+                Proveedor.id == proveedor_id
+            ).first()
+            
+            if not proveedor:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"Proveedor con ID {proveedor_id} no encontrado."
+                )
+            
+            return proveedor.to_dict()
+            
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error al obtener proveedor {proveedor_id}: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al obtener el proveedor."
+            )
+
+    def listar_proveedores(
+        self,
+        pais: Optional[str] = None,
+        tipo_proveedor: Optional[str] = None,
+        skip: int = 0,
+        limit: int = 100
+    ) -> List[Dict[str, Any]]:
+        """
+        Lista todos los proveedores con filtros opcionales.
+        
+        Args:
+            pais: Filtrar por país (opcional)
+            tipo_proveedor: Filtrar por tipo de proveedor (opcional)
+            skip: Número de registros a saltar (paginación)
+            limit: Número máximo de registros a retornar
+            
+        Returns:
+            Lista de proveedores
+        """
+        try:
+            query = self.db.query(Proveedor)
+            
+            if pais:
+                query = query.filter(Proveedor.pais == pais)
+            
+            if tipo_proveedor:
+                query = query.filter(Proveedor.tipo_proveedor == tipo_proveedor)
+            
+            query = query.order_by(Proveedor.fecha_creacion.desc())
+            
+            proveedores = query.offset(skip).limit(limit).all()
+            
+            return [proveedor.to_dict() for proveedor in proveedores]
+            
+        except Exception as e:
+            logger.error(f"Error al listar proveedores: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al listar proveedores."
+            )
+
+    def actualizar_proveedor(
+        self,
+        proveedor_id: str,
+        proveedor_data: ActualizarProveedorSchema
+    ) -> Dict[str, Any]:
+        """
+        Actualiza un proveedor existente.
+        
+        Args:
+            proveedor_id: ID del proveedor a actualizar
+            proveedor_data: Datos a actualizar
+            
+        Returns:
+            Dict con los datos del proveedor actualizado
+            
+        Raises:
+            HTTPException: Si el proveedor no existe o hay conflicto con datos únicos
+        """
+        try:
+            proveedor = self.db.query(Proveedor).filter(
+                Proveedor.id == proveedor_id
+            ).first()
+            
+            if not proveedor:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"Proveedor con ID {proveedor_id} no encontrado."
+                )
+            
+            # Verificar si el nuevo email ya existe en otro proveedor
+            if proveedor_data.email and proveedor_data.email != proveedor.email:
+                existing_by_email = self.db.query(Proveedor).filter(
+                    Proveedor.email == proveedor_data.email,
+                    Proveedor.id != proveedor_id
+                ).first()
+                
+                if existing_by_email:
+                    raise HTTPException(
+                        status_code=HTTPStatus.CONFLICT,
+                        detail=f"El email {proveedor_data.email} ya está registrado en otro proveedor."
+                    )
+            
+            # Actualizar solo los campos que se proporcionaron
+            update_data = proveedor_data.model_dump(exclude_unset=True)
+            
+            for field, value in update_data.items():
+                if value is not None:
+                    # Convertir enums a sus valores
+                    if hasattr(value, 'value'):
+                        value = value.value
+                    setattr(proveedor, field, value)
+            
+            proveedor.fecha_actualizacion = datetime.now(timezone.utc)
+            
+            self.db.commit()
+            self.db.refresh(proveedor)
+            
+            logger.info(f"Proveedor actualizado exitosamente: {proveedor_id}")
+            
+            return proveedor.to_dict()
+            
+        except HTTPException:
+            raise
+        except IntegrityError as e:
+            self.db.rollback()
+            logger.error(f"Error de integridad al actualizar proveedor: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.CONFLICT,
+                detail="El email ya existe en otro proveedor."
+            )
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Error al actualizar proveedor {proveedor_id}: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al actualizar el proveedor."
+            )
+
+    def eliminar_proveedor(self, proveedor_id: str) -> Dict[str, str]:
+        """
+        Elimina un proveedor del sistema.
+        
+        Args:
+            proveedor_id: ID del proveedor a eliminar
+            
+        Returns:
+            Dict con mensaje de confirmación
+            
+        Raises:
+            HTTPException: Si el proveedor no existe
+        """
+        try:
+            proveedor = self.db.query(Proveedor).filter(
+                Proveedor.id == proveedor_id
+            ).first()
+            
+            if not proveedor:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"Proveedor con ID {proveedor_id} no encontrado."
+                )
+            
+            self.db.delete(proveedor)
+            self.db.commit()
+            
+            logger.info(f"Proveedor eliminado exitosamente: {proveedor_id}")
+            
+            return {"message": "Proveedor eliminado exitosamente"}
+            
+        except HTTPException:
+            raise
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Error al eliminar proveedor {proveedor_id}: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al eliminar el proveedor."
+            )
+
+    def contar_proveedores(
+        self,
+        pais: Optional[str] = None,
+        tipo_proveedor: Optional[str] = None
+    ) -> int:
+        """
+        Cuenta el número total de proveedores con filtros opcionales.
+        
+        Args:
+            pais: Filtrar por país (opcional)
+            tipo_proveedor: Filtrar por tipo de proveedor (opcional)
+            
+        Returns:
+            Número total de proveedores
+        """
+        try:
+            query = self.db.query(Proveedor)
+            
+            if pais:
+                query = query.filter(Proveedor.pais == pais)
+            
+            if tipo_proveedor:
+                query = query.filter(Proveedor.tipo_proveedor == tipo_proveedor)
+            
+            return query.count()
+            
+        except Exception as e:
+            logger.error(f"Error al contar proveedores: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al contar proveedores."
+            )
+
+
+
+def get_proveedor_service(db: Session = Depends(get_db)) -> ProveedorService:
+    """
+    Función de dependencia para obtener una instancia del servicio de proveedores.
+    """
+    return ProveedorService(db)
+

--- a/src/proveedores/services/proveedor_service.py
+++ b/src/proveedores/services/proveedor_service.py
@@ -287,7 +287,7 @@ class ProveedorService:
                     )
             
             # Actualizar solo los campos que se proporcionaron
-            update_data = proveedor_data.model_dump(exclude_unset=True)
+            update_data = proveedor_data.model_dump(exclude_unset=True, exclude_none=True)
             
             for field, value in update_data.items():
                 if value is not None:

--- a/src/proveedores/tests/test_proveedor_schema.py
+++ b/src/proveedores/tests/test_proveedor_schema.py
@@ -1,0 +1,337 @@
+import pytest
+from pydantic import ValidationError
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from schemas.proveedor_schema import (
+    CrearProveedorSchema,
+    ActualizarProveedorSchema,
+    PaisEnum,
+    TipoProveedorEnum
+)
+
+
+class TestCrearProveedorSchema:
+    """Tests para validación del schema de creación de proveedor"""
+    
+    def test_schema_valido_peru(self):
+        """Test: Schema válido para Perú con RUC de 11 dígitos"""
+        # Arrange & Act
+        proveedor = CrearProveedorSchema(
+            nombre="Farmacéutica Nacional S.A.",
+            id_tributario="20123456789",
+            tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+            email="contacto@farmaceutica.com",
+            pais=PaisEnum.PERU,
+            contacto="Juan Pérez",
+            condiciones_entrega="Entrega en 5 días"
+        )
+        
+        # Assert
+        assert proveedor.nombre == "Farmacéutica Nacional S.A."
+        assert proveedor.id_tributario == "20123456789"
+        assert proveedor.pais == PaisEnum.PERU
+        
+    def test_schema_valido_colombia(self):
+        """Test: Schema válido para Colombia con NIT de 9 dígitos"""
+        # Arrange & Act
+        proveedor = CrearProveedorSchema(
+            nombre="Farmacia Colombia",
+            id_tributario="900123456",
+            tipo_proveedor=TipoProveedorEnum.DISTRIBUIDOR,
+            email="contacto@colombia.com",
+            pais=PaisEnum.COLOMBIA
+        )
+        
+        # Assert
+        assert proveedor.id_tributario == "900123456"
+        assert proveedor.pais == PaisEnum.COLOMBIA
+        
+    def test_schema_valido_colombia_10_digitos(self):
+        """Test: Schema válido para Colombia con NIT de 10 dígitos"""
+        # Arrange & Act
+        proveedor = CrearProveedorSchema(
+            nombre="Farmacia Colombia",
+            id_tributario="9001234567",
+            tipo_proveedor=TipoProveedorEnum.DISTRIBUIDOR,
+            email="contacto@colombia.com",
+            pais=PaisEnum.COLOMBIA
+        )
+        
+        # Assert
+        assert proveedor.id_tributario == "9001234567"
+        
+    def test_schema_valido_mexico(self):
+        """Test: Schema válido para México con RFC"""
+        # Arrange & Act
+        proveedor = CrearProveedorSchema(
+            nombre="Farmacia México",
+            id_tributario="ABC123456789",
+            tipo_proveedor=TipoProveedorEnum.MAYORISTA,
+            email="contacto@mexico.com",
+            pais=PaisEnum.MEXICO
+        )
+        
+        # Assert
+        assert proveedor.id_tributario == "ABC123456789"
+        assert proveedor.pais == PaisEnum.MEXICO
+        
+    def test_schema_valido_ecuador(self):
+        """Test: Schema válido para Ecuador con RUC de 13 dígitos"""
+        # Arrange & Act
+        proveedor = CrearProveedorSchema(
+            nombre="Farmacia Ecuador",
+            id_tributario="1234567890123",
+            tipo_proveedor=TipoProveedorEnum.IMPORTADOR,
+            email="contacto@ecuador.com",
+            pais=PaisEnum.ECUADOR
+        )
+        
+        # Assert
+        assert proveedor.id_tributario == "1234567890123"
+        assert proveedor.pais == PaisEnum.ECUADOR
+        
+    def test_ruc_peru_invalido_longitud(self):
+        """Test: Error con RUC de Perú con longitud incorrecta"""
+        # Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="201234567",  # Solo 9 dígitos
+                tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+                email="test@test.com",
+                pais=PaisEnum.PERU
+            )
+        
+        assert "RUC debe tener 11 dígitos" in str(exc_info.value)
+        
+    def test_ruc_peru_invalido_caracteres(self):
+        """Test: Error con RUC de Perú con caracteres no numéricos"""
+        # Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="2012345678A",  # Contiene letra
+                tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+                email="test@test.com",
+                pais=PaisEnum.PERU
+            )
+        
+        assert "RUC debe tener 11 dígitos" in str(exc_info.value)
+        
+    def test_nit_colombia_invalido(self):
+        """Test: Error con NIT de Colombia con longitud incorrecta"""
+        # Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="12345",  # Solo 5 dígitos
+                tipo_proveedor=TipoProveedorEnum.DISTRIBUIDOR,
+                email="test@test.com",
+                pais=PaisEnum.COLOMBIA
+            )
+        
+        assert "NIT debe tener 9 o 10 dígitos" in str(exc_info.value)
+        
+    def test_ruc_ecuador_invalido(self):
+        """Test: Error con RUC de Ecuador con longitud incorrecta"""
+        # Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="123456789012",  # Solo 12 dígitos
+                tipo_proveedor=TipoProveedorEnum.IMPORTADOR,
+                email="test@test.com",
+                pais=PaisEnum.ECUADOR
+            )
+        
+        assert "RUC debe tener 13 dígitos" in str(exc_info.value)
+        
+    def test_email_invalido(self):
+        """Test: Error con formato de email inválido"""
+        # Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="20123456789",
+                tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+                email="correo-invalido",  # No es un email válido
+                pais=PaisEnum.PERU
+            )
+        
+        assert "email" in str(exc_info.value).lower()
+        
+    def test_nombre_vacio(self):
+        """Test: Error con nombre vacío"""
+        # Act & Assert
+        with pytest.raises(ValidationError):
+            CrearProveedorSchema(
+                nombre="",
+                id_tributario="20123456789",
+                tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+                email="test@test.com",
+                pais=PaisEnum.PERU
+            )
+            
+    def test_nombre_muy_largo(self):
+        """Test: Error con nombre que excede 255 caracteres"""
+        # Act & Assert
+        with pytest.raises(ValidationError):
+            CrearProveedorSchema(
+                nombre="A" * 256,  # 256 caracteres
+                id_tributario="20123456789",
+                tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+                email="test@test.com",
+                pais=PaisEnum.PERU
+            )
+            
+    def test_contacto_muy_largo(self):
+        """Test: Error con contacto que excede 255 caracteres"""
+        # Act & Assert
+        with pytest.raises(ValidationError):
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="20123456789",
+                tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+                email="test@test.com",
+                pais=PaisEnum.PERU,
+                contacto="A" * 256  # 256 caracteres
+            )
+            
+    def test_condiciones_entrega_muy_largo(self):
+        """Test: Error con condiciones de entrega que exceden 500 caracteres"""
+        # Act & Assert
+        with pytest.raises(ValidationError):
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="20123456789",
+                tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+                email="test@test.com",
+                pais=PaisEnum.PERU,
+                condiciones_entrega="A" * 501  # 501 caracteres
+            )
+            
+    def test_campos_opcionales_none(self):
+        """Test: Schema válido con campos opcionales en None"""
+        # Arrange & Act
+        proveedor = CrearProveedorSchema(
+            nombre="Test",
+            id_tributario="20123456789",
+            tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+            email="test@test.com",
+            pais=PaisEnum.PERU,
+            contacto=None,
+            condiciones_entrega=None
+        )
+        
+        # Assert
+        assert proveedor.contacto is None
+        assert proveedor.condiciones_entrega is None
+        
+    def test_tipo_proveedor_invalido(self):
+        """Test: Error con tipo de proveedor inválido"""
+        # Act & Assert
+        with pytest.raises(ValidationError):
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="20123456789",
+                tipo_proveedor="TipoInvalido",  # No es un valor válido del enum
+                email="test@test.com",
+                pais=PaisEnum.PERU
+            )
+            
+    def test_pais_invalido(self):
+        """Test: Error con país inválido"""
+        # Act & Assert
+        with pytest.raises(ValidationError):
+            CrearProveedorSchema(
+                nombre="Test",
+                id_tributario="20123456789",
+                tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+                email="test@test.com",
+                pais="Argentina"  # No es un valor válido del enum
+            )
+
+
+class TestActualizarProveedorSchema:
+    """Tests para validación del schema de actualización de proveedor"""
+    
+    def test_actualizacion_parcial_nombre(self):
+        """Test: Actualización solo del nombre"""
+        # Arrange & Act
+        update = ActualizarProveedorSchema(nombre="Nuevo Nombre S.A.C.")
+        
+        # Assert
+        assert update.nombre == "Nuevo Nombre S.A.C."
+        assert update.email is None
+        assert update.contacto is None
+        
+    def test_actualizacion_parcial_email(self):
+        """Test: Actualización solo del email"""
+        # Arrange & Act
+        update = ActualizarProveedorSchema(email="nuevo@email.com")
+        
+        # Assert
+        assert update.email == "nuevo@email.com"
+        assert update.nombre is None
+        
+    def test_actualizacion_multiple_campos(self):
+        """Test: Actualización de múltiples campos"""
+        # Arrange & Act
+        update = ActualizarProveedorSchema(
+            nombre="Nuevo Nombre",
+            email="nuevo@email.com",
+            contacto="Nuevo Contacto"
+        )
+        
+        # Assert
+        assert update.nombre == "Nuevo Nombre"
+        assert update.email == "nuevo@email.com"
+        assert update.contacto == "Nuevo Contacto"
+        
+    def test_actualizacion_email_invalido(self):
+        """Test: Error al actualizar con email inválido"""
+        # Act & Assert
+        with pytest.raises(ValidationError):
+            ActualizarProveedorSchema(email="email-invalido")
+            
+    def test_actualizacion_nombre_muy_largo(self):
+        """Test: Error al actualizar con nombre muy largo"""
+        # Act & Assert
+        with pytest.raises(ValidationError):
+            ActualizarProveedorSchema(nombre="A" * 256)
+            
+    def test_actualizacion_sin_campos(self):
+        """Test: Schema válido sin campos (actualización vacía)"""
+        # Arrange & Act
+        update = ActualizarProveedorSchema()
+        
+        # Assert
+        assert update.nombre is None
+        assert update.email is None
+        assert update.tipo_proveedor is None
+        
+
+class TestEnums:
+    """Tests para los enums de país y tipo de proveedor"""
+    
+    def test_pais_enum_valores(self):
+        """Test: Verificar valores del enum PaisEnum"""
+        assert PaisEnum.COLOMBIA.value == "Colombia"
+        assert PaisEnum.PERU.value == "Perú"
+        assert PaisEnum.ECUADOR.value == "Ecuador"
+        assert PaisEnum.MEXICO.value == "México"
+        
+    def test_tipo_proveedor_enum_valores(self):
+        """Test: Verificar valores del enum TipoProveedorEnum"""
+        assert TipoProveedorEnum.FABRICANTE.value == "Fabricante"
+        assert TipoProveedorEnum.DISTRIBUIDOR.value == "Distribuidor"
+        assert TipoProveedorEnum.MAYORISTA.value == "Mayorista"
+        assert TipoProveedorEnum.IMPORTADOR.value == "Importador"
+        assert TipoProveedorEnum.MINORISTA.value == "Minorista"
+

--- a/src/proveedores/tests/test_proveedor_service.py
+++ b/src/proveedores/tests/test_proveedor_service.py
@@ -1,0 +1,309 @@
+import pytest
+from unittest.mock import Mock, MagicMock
+from fastapi import HTTPException
+from datetime import datetime
+import uuid
+
+from db.proveedor_model import Proveedor
+from schemas.proveedor_schema import (
+    CrearProveedorSchema,
+    ActualizarProveedorSchema,
+    PaisEnum,
+    TipoProveedorEnum
+)
+
+
+def get_service(mock_db):
+    """Helper function to get service instance"""
+    from services.proveedor_service import ProveedorService
+    return ProveedorService(db=mock_db)
+
+
+@pytest.fixture
+def mock_db():
+    """Fixture para crear un mock de la sesión de base de datos"""
+    db = MagicMock()
+    db.query.return_value = db
+    db.filter.return_value = db
+    db.offset.return_value = db
+    db.limit.return_value = db
+    db.order_by.return_value = db
+    return db
+
+
+@pytest.fixture
+def valid_proveedor_data():
+    """Fixture con datos válidos de proveedor"""
+    return CrearProveedorSchema(
+        nombre="Farmacéutica Nacional S.A.",
+        id_tributario="20123456789",
+        tipo_proveedor=TipoProveedorEnum.FABRICANTE,
+        email="contacto@farmaceutica.com",
+        pais=PaisEnum.PERU,
+        contacto="Juan Pérez - +51 999 888 777",
+        condiciones_entrega="Entrega en 5 días hábiles"
+    )
+
+
+@pytest.fixture
+def mock_proveedor():
+    """Fixture para crear un mock de proveedor"""
+    proveedor = Mock(spec=Proveedor)
+    proveedor.id = uuid.uuid4()
+    proveedor.fecha_creacion = datetime.now()
+    proveedor.fecha_actualizacion = datetime.now()
+    proveedor.nombre = "Farmacéutica Nacional S.A."
+    proveedor.id_tributario = "20123456789"
+    proveedor.tipo_proveedor = "Fabricante"
+    proveedor.email = "contacto@farmaceutica.com"
+    proveedor.pais = "Perú"
+    proveedor.contacto = "Juan Pérez"
+    proveedor.condiciones_entrega = "Entrega en 5 días"
+    
+    proveedor.to_dict.return_value = {
+        "id": str(proveedor.id),
+        "fecha_creacion": proveedor.fecha_creacion.isoformat(),
+        "fecha_actualizacion": proveedor.fecha_actualizacion.isoformat(),
+        "nombre": proveedor.nombre,
+        "id_tributario": proveedor.id_tributario,
+        "tipo_proveedor": proveedor.tipo_proveedor,
+        "email": proveedor.email,
+        "pais": proveedor.pais,
+        "contacto": proveedor.contacto,
+        "condiciones_entrega": proveedor.condiciones_entrega
+    }
+    
+    return proveedor
+
+
+class TestCrearProveedor:
+    """Tests para la creación de proveedores"""
+    
+    def test_crear_proveedor_exitoso(self, mock_db, valid_proveedor_data, mock_proveedor):
+        """Test: Crear un proveedor exitosamente"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        mock_db.first.return_value = None  # No existe proveedor duplicado
+        
+        # Act
+        result = proveedor_service.crear_proveedor(valid_proveedor_data)
+        
+        # Assert
+        assert mock_db.add.called
+        assert mock_db.commit.called
+        assert "nombre" in result
+        
+    def test_crear_proveedor_id_tributario_duplicado(self, mock_db, valid_proveedor_data, mock_proveedor):
+        """Test: Error al crear proveedor con ID tributario duplicado"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        mock_db.first.return_value = mock_proveedor  # Ya existe
+        
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            proveedor_service.crear_proveedor(valid_proveedor_data)
+        
+        assert exc_info.value.status_code == 409
+        assert "ID tributario" in exc_info.value.detail
+        
+    def test_crear_proveedor_email_duplicado(self, mock_db, valid_proveedor_data, mock_proveedor):
+        """Test: Error al crear proveedor con email duplicado"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        # Primera llamada (id_tributario) retorna None, segunda (email) retorna proveedor
+        mock_db.first.side_effect = [None, mock_proveedor]
+        
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            proveedor_service.crear_proveedor(valid_proveedor_data)
+        
+        assert exc_info.value.status_code == 409
+        assert "email" in exc_info.value.detail.lower()
+
+
+class TestObtenerProveedor:
+    """Tests para obtener un proveedor"""
+    
+    def test_obtener_proveedor_existente(self, mock_db, mock_proveedor):
+        """Test: Obtener un proveedor que existe"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        proveedor_id = str(uuid.uuid4())
+        mock_db.first.return_value = mock_proveedor
+        
+        # Act
+        result = proveedor_service.obtener_proveedor(proveedor_id)
+        
+        # Assert
+        assert result is not None
+        assert "nombre" in result
+        
+    def test_obtener_proveedor_no_existente(self, mock_db):
+        """Test: Error al obtener un proveedor que no existe"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        proveedor_id = str(uuid.uuid4())
+        mock_db.first.return_value = None
+        
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            proveedor_service.obtener_proveedor(proveedor_id)
+        
+        assert exc_info.value.status_code == 404
+
+
+class TestListarProveedores:
+    """Tests para listar proveedores"""
+    
+    def test_listar_proveedores_sin_filtros(self, mock_db, mock_proveedor):
+        """Test: Listar todos los proveedores sin filtros"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        mock_db.all.return_value = [mock_proveedor, mock_proveedor]
+        
+        # Act
+        result = proveedor_service.listar_proveedores()
+        
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 2
+        
+    def test_listar_proveedores_con_filtro_pais(self, mock_db, mock_proveedor):
+        """Test: Listar proveedores filtrados por país"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        mock_db.all.return_value = [mock_proveedor]
+        
+        # Act
+        result = proveedor_service.listar_proveedores(pais="Perú")
+        
+        # Assert
+        assert mock_db.filter.called
+        assert len(result) == 1
+        
+    def test_listar_proveedores_con_paginacion(self, mock_db, mock_proveedor):
+        """Test: Listar proveedores con paginación"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        mock_db.all.return_value = [mock_proveedor]
+        
+        # Act
+        result = proveedor_service.listar_proveedores(skip=10, limit=5)
+        
+        # Assert
+        assert mock_db.offset.called
+        assert mock_db.limit.called
+
+
+class TestActualizarProveedor:
+    """Tests para actualizar proveedores"""
+    
+    def test_actualizar_proveedor_exitoso(self, mock_db, mock_proveedor):
+        """Test: Actualizar un proveedor exitosamente"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        proveedor_id = str(uuid.uuid4())
+        mock_db.first.return_value = mock_proveedor
+        update_data = ActualizarProveedorSchema(
+            nombre="Nuevo Nombre S.A.C."
+        )
+        
+        # Act
+        result = proveedor_service.actualizar_proveedor(proveedor_id, update_data)
+        
+        # Assert
+        assert mock_db.commit.called
+        assert result is not None
+        
+    def test_actualizar_proveedor_no_existente(self, mock_db):
+        """Test: Error al actualizar un proveedor que no existe"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        proveedor_id = str(uuid.uuid4())
+        mock_db.first.return_value = None
+        update_data = ActualizarProveedorSchema(nombre="Nuevo Nombre")
+        
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            proveedor_service.actualizar_proveedor(proveedor_id, update_data)
+        
+        assert exc_info.value.status_code == 404
+        
+    def test_actualizar_proveedor_email_duplicado(self, mock_db, mock_proveedor):
+        """Test: Error al actualizar con email que ya existe"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        proveedor_id = str(uuid.uuid4())
+        otro_proveedor = Mock(spec=Proveedor)
+        otro_proveedor.email = "otro@email.com"
+        
+        mock_db.first.side_effect = [mock_proveedor, otro_proveedor]
+        update_data = ActualizarProveedorSchema(email="otro@email.com")
+        
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            proveedor_service.actualizar_proveedor(proveedor_id, update_data)
+        
+        assert exc_info.value.status_code == 409
+
+
+class TestEliminarProveedor:
+    """Tests para eliminar proveedores"""
+    
+    def test_eliminar_proveedor_exitoso(self, mock_db, mock_proveedor):
+        """Test: Eliminar un proveedor exitosamente"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        proveedor_id = str(uuid.uuid4())
+        mock_db.first.return_value = mock_proveedor
+        
+        # Act
+        result = proveedor_service.eliminar_proveedor(proveedor_id)
+        
+        # Assert
+        assert mock_db.delete.called
+        assert mock_db.commit.called
+        assert "message" in result
+        
+    def test_eliminar_proveedor_no_existente(self, mock_db):
+        """Test: Error al eliminar un proveedor que no existe"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        proveedor_id = str(uuid.uuid4())
+        mock_db.first.return_value = None
+        
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            proveedor_service.eliminar_proveedor(proveedor_id)
+        
+        assert exc_info.value.status_code == 404
+
+
+class TestContarProveedores:
+    """Tests para contar proveedores"""
+    
+    def test_contar_proveedores_sin_filtros(self, mock_db):
+        """Test: Contar todos los proveedores"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        mock_db.count.return_value = 10
+        
+        # Act
+        result = proveedor_service.contar_proveedores()
+        
+        # Assert
+        assert result == 10
+        
+    def test_contar_proveedores_con_filtros(self, mock_db):
+        """Test: Contar proveedores con filtros"""
+        # Arrange
+        proveedor_service = get_service(mock_db)
+        mock_db.count.return_value = 5
+        
+        # Act
+        result = proveedor_service.contar_proveedores(pais="Perú", tipo_proveedor="Fabricante")
+        
+        # Assert
+        assert mock_db.filter.called
+        assert result == 5
+

--- a/src/proveedores/tests/test_proveedor_service.py
+++ b/src/proveedores/tests/test_proveedor_service.py
@@ -1,8 +1,9 @@
 import pytest
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, patch
 from fastapi import HTTPException
 from datetime import datetime
 import uuid
+import json
 
 from db.proveedor_model import Proveedor
 from schemas.proveedor_schema import (
@@ -13,10 +14,12 @@ from schemas.proveedor_schema import (
 )
 
 
-def get_service(mock_db):
+def get_service(mock_db, mock_redis=None):
     """Helper function to get service instance"""
-    from services.proveedor_service import ProveedorService
-    return ProveedorService(db=mock_db)
+    with patch('services.proveedor_service.get_redis_client') as mock_get_redis:
+        mock_get_redis.return_value = mock_redis
+        from services.proveedor_service import ProveedorService
+        return ProveedorService(db=mock_db)
 
 
 @pytest.fixture
@@ -29,6 +32,17 @@ def mock_db():
     db.limit.return_value = db
     db.order_by.return_value = db
     return db
+
+
+@pytest.fixture
+def mock_redis():
+    """Fixture para crear un mock del cliente Redis"""
+    redis_mock = MagicMock()
+    redis_mock.get.return_value = None  # Default: no cache hit
+    redis_mock.setex.return_value = True
+    redis_mock.delete.return_value = 0
+    redis_mock.keys.return_value = []
+    return redis_mock
 
 
 @pytest.fixture
@@ -79,10 +93,10 @@ def mock_proveedor():
 class TestCrearProveedor:
     """Tests para la creación de proveedores"""
     
-    def test_crear_proveedor_exitoso(self, mock_db, valid_proveedor_data, mock_proveedor):
+    def test_crear_proveedor_exitoso(self, mock_db, mock_redis, valid_proveedor_data, mock_proveedor):
         """Test: Crear un proveedor exitosamente"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         mock_db.first.return_value = None  # No existe proveedor duplicado
         
         # Act
@@ -92,11 +106,12 @@ class TestCrearProveedor:
         assert mock_db.add.called
         assert mock_db.commit.called
         assert "nombre" in result
+        assert mock_redis.keys.called
         
-    def test_crear_proveedor_id_tributario_duplicado(self, mock_db, valid_proveedor_data, mock_proveedor):
+    def test_crear_proveedor_id_tributario_duplicado(self, mock_db, mock_redis, valid_proveedor_data, mock_proveedor):
         """Test: Error al crear proveedor con ID tributario duplicado"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         mock_db.first.return_value = mock_proveedor  # Ya existe
         
         # Act & Assert
@@ -106,10 +121,10 @@ class TestCrearProveedor:
         assert exc_info.value.status_code == 409
         assert "ID tributario" in exc_info.value.detail
         
-    def test_crear_proveedor_email_duplicado(self, mock_db, valid_proveedor_data, mock_proveedor):
+    def test_crear_proveedor_email_duplicado(self, mock_db, mock_redis, valid_proveedor_data, mock_proveedor):
         """Test: Error al crear proveedor con email duplicado"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         # Primera llamada (id_tributario) retorna None, segunda (email) retorna proveedor
         mock_db.first.side_effect = [None, mock_proveedor]
         
@@ -124,12 +139,13 @@ class TestCrearProveedor:
 class TestObtenerProveedor:
     """Tests para obtener un proveedor"""
     
-    def test_obtener_proveedor_existente(self, mock_db, mock_proveedor):
-        """Test: Obtener un proveedor que existe"""
+    def test_obtener_proveedor_existente_sin_cache(self, mock_db, mock_redis, mock_proveedor):
+        """Test: Obtener un proveedor que existe (cache miss)"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         proveedor_id = str(uuid.uuid4())
         mock_db.first.return_value = mock_proveedor
+        mock_redis.get.return_value = None  # Cache miss
         
         # Act
         result = proveedor_service.obtener_proveedor(proveedor_id)
@@ -137,13 +153,32 @@ class TestObtenerProveedor:
         # Assert
         assert result is not None
         assert "nombre" in result
+        assert mock_db.first.called  # DB was queried
+        assert mock_redis.setex.called  # Cache was set
         
-    def test_obtener_proveedor_no_existente(self, mock_db):
+    def test_obtener_proveedor_desde_cache(self, mock_db, mock_redis, mock_proveedor):
+        """Test: Obtener un proveedor desde cache (cache hit)"""
+        # Arrange
+        proveedor_service = get_service(mock_db, mock_redis)
+        proveedor_id = str(uuid.uuid4())
+        cached_data = mock_proveedor.to_dict()
+        mock_redis.get.return_value = json.dumps(cached_data)
+        
+        # Act
+        result = proveedor_service.obtener_proveedor(proveedor_id)
+        
+        # Assert
+        assert result is not None
+        assert "nombre" in result
+        assert not mock_db.first.called  # DB was NOT queried
+        
+    def test_obtener_proveedor_no_existente(self, mock_db, mock_redis):
         """Test: Error al obtener un proveedor que no existe"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         proveedor_id = str(uuid.uuid4())
         mock_db.first.return_value = None
+        mock_redis.get.return_value = None
         
         # Act & Assert
         with pytest.raises(HTTPException) as exc_info:
@@ -155,11 +190,12 @@ class TestObtenerProveedor:
 class TestListarProveedores:
     """Tests para listar proveedores"""
     
-    def test_listar_proveedores_sin_filtros(self, mock_db, mock_proveedor):
+    def test_listar_proveedores_sin_filtros(self, mock_db, mock_redis, mock_proveedor):
         """Test: Listar todos los proveedores sin filtros"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         mock_db.all.return_value = [mock_proveedor, mock_proveedor]
+        mock_redis.get.return_value = None  # Cache miss
         
         # Act
         result = proveedor_service.listar_proveedores()
@@ -167,12 +203,14 @@ class TestListarProveedores:
         # Assert
         assert isinstance(result, list)
         assert len(result) == 2
+        assert mock_redis.setex.called  # Cache was set
         
-    def test_listar_proveedores_con_filtro_pais(self, mock_db, mock_proveedor):
+    def test_listar_proveedores_con_filtro_pais(self, mock_db, mock_redis, mock_proveedor):
         """Test: Listar proveedores filtrados por país"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         mock_db.all.return_value = [mock_proveedor]
+        mock_redis.get.return_value = None  # Cache miss
         
         # Act
         result = proveedor_service.listar_proveedores(pais="Perú")
@@ -181,11 +219,12 @@ class TestListarProveedores:
         assert mock_db.filter.called
         assert len(result) == 1
         
-    def test_listar_proveedores_con_paginacion(self, mock_db, mock_proveedor):
+    def test_listar_proveedores_con_paginacion(self, mock_db, mock_redis, mock_proveedor):
         """Test: Listar proveedores con paginación"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         mock_db.all.return_value = [mock_proveedor]
+        mock_redis.get.return_value = None  # Cache miss
         
         # Act
         result = proveedor_service.listar_proveedores(skip=10, limit=5)
@@ -193,15 +232,30 @@ class TestListarProveedores:
         # Assert
         assert mock_db.offset.called
         assert mock_db.limit.called
+        
+    def test_listar_proveedores_desde_cache(self, mock_db, mock_redis, mock_proveedor):
+        """Test: Listar proveedores desde cache (cache hit)"""
+        # Arrange
+        proveedor_service = get_service(mock_db, mock_redis)
+        cached_data = [mock_proveedor.to_dict()]
+        mock_redis.get.return_value = json.dumps(cached_data)
+        
+        # Act
+        result = proveedor_service.listar_proveedores()
+        
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert not mock_db.all.called  # DB was NOT queried
 
 
 class TestActualizarProveedor:
     """Tests para actualizar proveedores"""
     
-    def test_actualizar_proveedor_exitoso(self, mock_db, mock_proveedor):
+    def test_actualizar_proveedor_exitoso(self, mock_db, mock_redis, mock_proveedor):
         """Test: Actualizar un proveedor exitosamente"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         proveedor_id = str(uuid.uuid4())
         mock_db.first.return_value = mock_proveedor
         update_data = ActualizarProveedorSchema(
@@ -214,11 +268,12 @@ class TestActualizarProveedor:
         # Assert
         assert mock_db.commit.called
         assert result is not None
+        assert mock_redis.keys.called
         
-    def test_actualizar_proveedor_no_existente(self, mock_db):
+    def test_actualizar_proveedor_no_existente(self, mock_db, mock_redis):
         """Test: Error al actualizar un proveedor que no existe"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         proveedor_id = str(uuid.uuid4())
         mock_db.first.return_value = None
         update_data = ActualizarProveedorSchema(nombre="Nuevo Nombre")
@@ -229,10 +284,10 @@ class TestActualizarProveedor:
         
         assert exc_info.value.status_code == 404
         
-    def test_actualizar_proveedor_email_duplicado(self, mock_db, mock_proveedor):
+    def test_actualizar_proveedor_email_duplicado(self, mock_db, mock_redis, mock_proveedor):
         """Test: Error al actualizar con email que ya existe"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         proveedor_id = str(uuid.uuid4())
         otro_proveedor = Mock(spec=Proveedor)
         otro_proveedor.email = "otro@email.com"
@@ -250,10 +305,10 @@ class TestActualizarProveedor:
 class TestEliminarProveedor:
     """Tests para eliminar proveedores"""
     
-    def test_eliminar_proveedor_exitoso(self, mock_db, mock_proveedor):
+    def test_eliminar_proveedor_exitoso(self, mock_db, mock_redis, mock_proveedor):
         """Test: Eliminar un proveedor exitosamente"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         proveedor_id = str(uuid.uuid4())
         mock_db.first.return_value = mock_proveedor
         
@@ -264,11 +319,12 @@ class TestEliminarProveedor:
         assert mock_db.delete.called
         assert mock_db.commit.called
         assert "message" in result
+        assert mock_redis.keys.called
         
-    def test_eliminar_proveedor_no_existente(self, mock_db):
+    def test_eliminar_proveedor_no_existente(self, mock_db, mock_redis):
         """Test: Error al eliminar un proveedor que no existe"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         proveedor_id = str(uuid.uuid4())
         mock_db.first.return_value = None
         
@@ -282,23 +338,26 @@ class TestEliminarProveedor:
 class TestContarProveedores:
     """Tests para contar proveedores"""
     
-    def test_contar_proveedores_sin_filtros(self, mock_db):
+    def test_contar_proveedores_sin_filtros(self, mock_db, mock_redis):
         """Test: Contar todos los proveedores"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         mock_db.count.return_value = 10
+        mock_redis.get.return_value = None  # Cache miss
         
         # Act
         result = proveedor_service.contar_proveedores()
         
         # Assert
         assert result == 10
+        assert mock_redis.setex.called  # Cache was set
         
-    def test_contar_proveedores_con_filtros(self, mock_db):
+    def test_contar_proveedores_con_filtros(self, mock_db, mock_redis):
         """Test: Contar proveedores con filtros"""
         # Arrange
-        proveedor_service = get_service(mock_db)
+        proveedor_service = get_service(mock_db, mock_redis)
         mock_db.count.return_value = 5
+        mock_redis.get.return_value = None  # Cache miss
         
         # Act
         result = proveedor_service.contar_proveedores(pais="Perú", tipo_proveedor="Fabricante")
@@ -306,4 +365,77 @@ class TestContarProveedores:
         # Assert
         assert mock_db.filter.called
         assert result == 5
+        
+    def test_contar_proveedores_desde_cache(self, mock_db, mock_redis):
+        """Test: Contar proveedores desde cache (cache hit)"""
+        # Arrange
+        proveedor_service = get_service(mock_db, mock_redis)
+        mock_redis.get.return_value = json.dumps(15)
+        
+        # Act
+        result = proveedor_service.contar_proveedores()
+        
+        # Assert
+        assert result == 15
+        assert not mock_db.count.called  # DB was NOT queried
+
+
+class TestCacheGracefulDegradation:
+    """Tests para verificar degradación graciosa cuando Redis no está disponible"""
+    
+    def test_obtener_proveedor_sin_redis(self, mock_db, mock_proveedor):
+        """Test: Obtener proveedor funciona sin Redis disponible"""
+        # Arrange
+        proveedor_service = get_service(mock_db, None)  # Redis is None
+        proveedor_id = str(uuid.uuid4())
+        mock_db.first.return_value = mock_proveedor
+        
+        # Act
+        result = proveedor_service.obtener_proveedor(proveedor_id)
+        
+        # Assert
+        assert result is not None
+        assert "nombre" in result
+        assert mock_db.first.called
+        
+    def test_listar_proveedores_sin_redis(self, mock_db, mock_proveedor):
+        """Test: Listar proveedores funciona sin Redis disponible"""
+        # Arrange
+        proveedor_service = get_service(mock_db, None)  # Redis is None
+        mock_db.all.return_value = [mock_proveedor]
+        
+        # Act
+        result = proveedor_service.listar_proveedores()
+        
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 1
+        
+    def test_crear_proveedor_sin_redis(self, mock_db, valid_proveedor_data):
+        """Test: Crear proveedor funciona sin Redis disponible"""
+        # Arrange
+        proveedor_service = get_service(mock_db, None)  # Redis is None
+        mock_db.first.return_value = None
+        
+        # Act
+        result = proveedor_service.crear_proveedor(valid_proveedor_data)
+        
+        # Assert
+        assert mock_db.add.called
+        assert mock_db.commit.called
+        
+    def test_cache_error_handling(self, mock_db, mock_redis, mock_proveedor):
+        """Test: Manejar errores de Redis graciosamente"""
+        # Arrange
+        proveedor_service = get_service(mock_db, mock_redis)
+        proveedor_id = str(uuid.uuid4())
+        mock_db.first.return_value = mock_proveedor
+        mock_redis.get.side_effect = Exception("Redis connection error")
+        
+        # Act
+        result = proveedor_service.obtener_proveedor(proveedor_id)
+        
+        assert result is not None
+        assert "nombre" in result
+        assert mock_db.first.called
 


### PR DESCRIPTION
This pull request refactors and improves both the API endpoints for proveedores (suppliers) in `src/bff-web/router/proveedores.py` and the corresponding Postman collection in `collection/Medisupply.postman_collection.json`. The main goals are to provide a more RESTful and robust API, enhance documentation and validation, and make the Postman tests more dynamic and maintainable. The changes introduce proper CRUD operations, add request/response validation, and update the test collection to use dynamic variables and scripts for better automation.

**API Endpoint Improvements**

* Added full CRUD endpoints for proveedores: create (`POST /proveedores`), list with filters and pagination (`GET /proveedores`), retrieve by ID (`GET /proveedores/{id}`), update (`PUT /proveedores/{id}`), and delete (`DELETE /proveedores/{id}`), each with detailed documentation, validation, and response schemas.

**Postman Collection Refactor**

* Updated the Postman collection to match the new API structure: endpoints now use dynamic variables (e.g., `{{id_proveedor}}`), and each request is paired with pre-request and test scripts to automate variable assignment and chaining between requests. [[1]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL17-R105) [[2]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fR1203-R1229)
* Improved request bodies to use dynamic values and Postman variable syntax (e.g., `{{$randomFullName}}`, `{{id_tributario}}`) for better test coverage and realism. [[1]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL1201-R1249) [[2]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL1308-R1350)
* Standardized the use of collection variables for supplier ID and tax ID, and removed hardcoded or outdated variable assignment logic.

**Endpoint and Variable Consistency**

* Fixed URL and variable usage in Postman requests to ensure consistency and correctness (e.g., removing unnecessary query strings, using `{{id_proveedor}}` instead of legacy response extraction syntax). [[1]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL127-R199) [[2]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL1263-R1322) [[3]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL1327-R1369) [[4]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL1361-R1403) [[5]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL178-L212) [[6]](diffhunk://#diff-a0feef0ee786a4524aa6ea65c1e920d922355a5b8da2fc63b95ef64c7186504fL225-R246)

These changes collectively modernize the proveedores API and its test collection, making it easier to use, maintain, and extend.