### PR TITLE
Update bffs health to not to send error code when some services are down

### DIFF
--- a/src/bff-movil/main.py
+++ b/src/bff-movil/main.py
@@ -28,9 +28,6 @@ def health_check(
     health_service: HealthService = Depends(get_health_service)
 ):
     health_status = health_service.check_overall_health(include_details=details)
-    
-    if health_status["status"] != "healthy":
-        raise HTTPException(status_code=503, detail=health_status)
-    
+
     return health_status
 

--- a/src/bff-web/main.py
+++ b/src/bff-web/main.py
@@ -54,8 +54,5 @@ def health_check(
 ):
     health_status = health_service.check_overall_health(include_details=details)
     
-    if health_status["status"] != "healthy":
-        raise HTTPException(status_code=503, detail=health_status)
-    
     return health_status
 


### PR DESCRIPTION
Update bffs health to not to send error code when some services are down, to allow load balancer to start