### PR TITLE
Feature/medsup 116 planes venta

### DIFF
--- a/collection/Medisupply.postman_collection.json
+++ b/collection/Medisupply.postman_collection.json
@@ -2187,7 +2187,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"documento_identidad\": \"{{$randomInt}}\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"zona_asignada\": \"Perú\",\n\t\"plan_venta\": \"plan-{{$randomInt}}\",\n\t\"meta_venta\": 50000.00\n}",
+							"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"documento_identidad\": \"{{$randomInt}}\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"zona_asignada\": \"Perú\",\n\t\"plan_venta_id\": \"{{id_plan_venta}}\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2288,7 +2288,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"zona_asignada\": \"Colombia\",\n\t\"meta_venta\": 75000.00\n}",
+							"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"zona_asignada\": \"Colombia\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/collection/Medisupply.postman_collection.json
+++ b/collection/Medisupply.postman_collection.json
@@ -451,7 +451,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"documento_identidad\": \"{{$randomInt}}\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"zona_asignada\": \"Perú\",\n\t\"plan_venta\": \"plan-{{$randomInt}}\",\n\t\"meta_venta\": 50000.00\n}",
+									"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"documento_identidad\": \"{{$randomInt}}\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"zona_asignada\": \"Perú\",\n\t\"plan_venta_id\": \"{{id_plan_venta}}\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -555,7 +555,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"zona_asignada\": \"Colombia\",\n\t\"meta_venta\": 75000.00\n}",
+									"raw": "{\n\t\"nombre\": \"{{$randomFullName}}\",\n\t\"email\": \"{{$randomEmail}}\",\n\t\"zona_asignada\": \"Colombia\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -576,6 +576,208 @@
 										{
 											"key": "id",
 											"value": "{{id_vendedor}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "crear plan de venta",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const response = pm.response.json();",
+											"const id = response.data?.id",
+											"pm.collectionVariables.set(\"id_plan_venta\", id);"
+										],
+										"type": "text/javascript",
+										"packages": {},
+										"requests": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"followRedirects": true,
+								"disableUrlEncoding": false,
+								"disableCookies": false
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "User-Agent",
+										"value": "insomnia/11.6.1"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"nombre\": \"Plan Q1 2025 - Perú\",\n\t\"fecha_inicio\": \"2025-01-01T00:00:00\",\n\t\"fecha_fin\": \"2025-03-31T23:59:59\",\n\t\"descripcion\": \"Plan de ventas del primer trimestre para la región de Perú\",\n\t\"meta_venta\": 100000.00,\n\t\"zona_asignada\": \"Perú\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ _.bff_web_url }}/ventas/planes",
+									"host": [
+										"{{ _.bff_web_url }}"
+									],
+									"path": [
+										"ventas",
+										"planes"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "listar planes de venta",
+							"protocolProfileBehavior": {
+								"followRedirects": true,
+								"disableUrlEncoding": false,
+								"disableCookies": false
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "User-Agent",
+										"value": "insomnia/11.6.1"
+									}
+								],
+								"url": {
+									"raw": "{{ _.bff_web_url }}/ventas/planes",
+									"host": [
+										"{{ _.bff_web_url }}"
+									],
+									"path": [
+										"ventas",
+										"planes"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "obtener plan de venta",
+							"protocolProfileBehavior": {
+								"followRedirects": true,
+								"disableUrlEncoding": false,
+								"disableCookies": false
+							},
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "User-Agent",
+										"value": "insomnia/11.6.1"
+									}
+								],
+								"url": {
+									"raw": "{{ _.bff_web_url }}/ventas/planes/:id",
+									"host": [
+										"{{ _.bff_web_url }}"
+									],
+									"path": [
+										"ventas",
+										"planes",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "{{id_plan_venta}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "actualizar plan de venta",
+							"protocolProfileBehavior": {
+								"followRedirects": true,
+								"disableUrlEncoding": false,
+								"disableCookies": false
+							},
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "User-Agent",
+										"value": "insomnia/11.6.1"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"nombre\": \"Plan Q1 2025 - Perú (Actualizado)\",\n\t\"meta_venta\": 150000.00,\n\t\"descripcion\": \"Meta incrementada debido a buen desempeño\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{ _.bff_web_url }}/ventas/planes/:id",
+									"host": [
+										"{{ _.bff_web_url }}"
+									],
+									"path": [
+										"ventas",
+										"planes",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "{{id_plan_venta}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "eliminar plan de venta",
+							"protocolProfileBehavior": {
+								"followRedirects": true,
+								"disableUrlEncoding": false,
+								"disableCookies": false
+							},
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "User-Agent",
+										"value": "insomnia/11.6.1"
+									}
+								],
+								"url": {
+									"raw": "{{ _.bff_web_url }}/ventas/planes/:id",
+									"host": [
+										"{{ _.bff_web_url }}"
+									],
+									"path": [
+										"ventas",
+										"planes",
+										":id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "{{id_plan_venta}}"
 										}
 									]
 								}

--- a/collection/Medisupply.postman_collection.json
+++ b/collection/Medisupply.postman_collection.json
@@ -2313,6 +2313,221 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "crear plan venta",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const response = pm.response.json();",
+									"const id = response.data?.id",
+									"pm.collectionVariables.set(\"id_plan_venta\", id);"
+								],
+								"type": "text/javascript",
+								"packages": {},
+								"requests": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"followRedirects": true,
+						"disableUrlEncoding": false,
+						"disableCookies": false
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "User-Agent",
+								"value": "insomnia/11.6.1"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"nombre\": \"Plan Q1 2025 - {{$randomCountry}}\",\n\t\"fecha_inicio\": \"2025-01-01T00:00:00\",\n\t\"fecha_fin\": \"2025-03-31T23:59:59\",\n\t\"descripcion\": \"Plan de ventas del primer trimestre para la región\",\n\t\"meta_venta\": 100000.00,\n\t\"zona_asignada\": \"Perú\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{ _.ventas_url }}/planes-venta",
+							"host": [
+								"{{ _.ventas_url }}"
+							],
+							"path": [
+								"planes-venta"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "listar planes venta",
+					"protocolProfileBehavior": {
+						"followRedirects": true,
+						"disableUrlEncoding": false,
+						"disableCookies": false
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "User-Agent",
+								"value": "insomnia/11.6.1"
+							}
+						],
+						"url": {
+							"raw": "{{ _.ventas_url }}/planes-venta?page=1&page_size=20",
+							"host": [
+								"{{ _.ventas_url }}"
+							],
+							"path": [
+								"planes-venta"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Número de página"
+								},
+								{
+									"key": "page_size",
+									"value": "20",
+									"description": "Tamaño de página"
+								},
+								{
+									"key": "zona_asignada",
+									"value": "Perú",
+									"description": "Filtrar por zona (opcional)",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "obtener plan venta",
+					"protocolProfileBehavior": {
+						"followRedirects": true,
+						"disableUrlEncoding": false,
+						"disableCookies": false
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "User-Agent",
+								"value": "insomnia/11.6.1"
+							}
+						],
+						"url": {
+							"raw": "{{ _.ventas_url }}/planes-venta/:id",
+							"host": [
+								"{{ _.ventas_url }}"
+							],
+							"path": [
+								"planes-venta",
+								":id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "{{id_plan_venta}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "actualizar plan venta",
+					"protocolProfileBehavior": {
+						"followRedirects": true,
+						"disableUrlEncoding": false,
+						"disableCookies": false
+					},
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "User-Agent",
+								"value": "insomnia/11.6.1"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"nombre\": \"Plan Q1 2025 - {{$randomCountry}} (Actualizado)\",\n\t\"meta_venta\": 150000.00,\n\t\"descripcion\": \"Meta incrementada debido a buen desempeño\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{ _.ventas_url }}/planes-venta/:id",
+							"host": [
+								"{{ _.ventas_url }}"
+							],
+							"path": [
+								"planes-venta",
+								":id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "{{id_plan_venta}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "eliminar plan venta",
+					"protocolProfileBehavior": {
+						"followRedirects": true,
+						"disableUrlEncoding": false,
+						"disableCookies": false
+					},
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "User-Agent",
+								"value": "insomnia/11.6.1"
+							}
+						],
+						"url": {
+							"raw": "{{ _.ventas_url }}/planes-venta/:id",
+							"host": [
+								"{{ _.ventas_url }}"
+							],
+							"path": [
+								"planes-venta",
+								":id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "{{id_plan_venta}}"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -2779,6 +2994,10 @@
 		},
 		{
 			"key": "id_vendedor",
+			"value": ""
+		},
+		{
+			"key": "id_plan_venta",
 			"value": ""
 		},
 		{

--- a/src/bff-web/router/planes_venta.py
+++ b/src/bff-web/router/planes_venta.py
@@ -1,0 +1,192 @@
+from fastapi import APIRouter, Depends, Query, status
+from typing import Optional
+import logging
+
+from services.planes_venta_service import PlanesVentaService, get_planes_venta_service
+from schemas.plan_venta_schema import (
+    CrearPlanVentaSchema,
+    ActualizarPlanVentaSchema,
+)
+from schemas.vendedor_schema import ZonaAsignadaEnum
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+planes_venta_router = APIRouter()
+
+
+@planes_venta_router.post(
+    "",
+    response_model=dict,
+    status_code=status.HTTP_201_CREATED,
+    summary="Crear nuevo plan de venta",
+    description="Crea un nuevo plan de venta en el sistema con validación de nombre único",
+    responses={
+        201: {
+            "description": "Plan de venta creado exitosamente",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "message": "Creación exitosa",
+                        "data": {
+                            "id": "550e8400-e29b-41d4-a716-446655440000",
+                            "nombre": "Plan Q1 2024 - Perú",
+                            "fecha_inicio": "2024-01-01T00:00:00",
+                            "fecha_fin": "2024-03-31T23:59:59",
+                            "meta_venta": "100000.00",
+                            "zona_asignada": "Perú"
+                        }
+                    }
+                }
+            }
+        },
+        409: {"description": "Nombre del plan ya existe"},
+        422: {"description": "Error de validación en los datos"}
+    }
+)
+async def crear_plan_venta(
+    plan: CrearPlanVentaSchema,
+    planes_service: PlanesVentaService = Depends(get_planes_venta_service)
+):
+    """
+    Crea un nuevo plan de venta con los siguientes datos:
+
+    - **nombre**: Nombre del plan (obligatorio, único)
+    - **fecha_inicio**: Fecha de inicio del plan (obligatorio)
+    - **fecha_fin**: Fecha de fin del plan (obligatorio, debe ser posterior a fecha_inicio)
+    - **meta_venta**: Meta de ventas en monto monetario (obligatorio, mayor a 0)
+    - **descripcion**: Descripción del plan (opcional)
+    - **zona_asignada**: Zona/país asignado (opcional)
+    """
+    data = await planes_service.crear_plan_venta(plan.model_dump())
+    return data
+
+
+@planes_venta_router.get(
+    "",
+    response_model=dict,
+    summary="Listar planes de venta",
+    description="Obtiene listado de planes de venta con paginación y filtros opcionales",
+    responses={
+        200: {
+            "description": "Lista de planes de venta obtenida exitosamente",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "data": [
+                            {
+                                "id": "550e8400-e29b-41d4-a716-446655440000",
+                                "nombre": "Plan Q1 2024 - Perú",
+                                "fecha_inicio": "2024-01-01T00:00:00",
+                                "fecha_fin": "2024-03-31T23:59:59",
+                                "meta_venta": "100000.00",
+                                "zona_asignada": "Perú"
+                            }
+                        ],
+                        "total": 1,
+                        "page": 1,
+                        "page_size": 20,
+                        "total_pages": 1
+                    }
+                }
+            }
+        }
+    }
+)
+async def listar_planes_venta(
+    page: int = Query(1, ge=1, description="Número de página"),
+    page_size: int = Query(20, ge=1, le=100, description="Tamaño de página (máximo 100)"),
+    nombre: Optional[str] = Query(None, description="Filtrar por nombre (búsqueda parcial)"),
+    zona_asignada: Optional[str] = Query(None, description="Filtrar por zona asignada"),
+    planes_service: PlanesVentaService = Depends(get_planes_venta_service)
+):
+    """
+    Lista todos los planes de venta con opciones de:
+
+    - **Paginación**: Con page (número de página) y page_size (tamaño)
+    - **Filtros**: Por nombre y zona_asignada
+    - **Ordenamiento**: Por fecha de creación (más recientes primero)
+    """
+    data = await planes_service.listar_planes_venta(
+        page=page,
+        page_size=page_size,
+        nombre=nombre,
+        zona_asignada=zona_asignada
+    )
+
+    return data
+
+
+@planes_venta_router.get(
+    "/{plan_id}",
+    response_model=dict,
+    summary="Obtener plan de venta por ID",
+    description="Obtiene los detalles completos de un plan de venta específico",
+    responses={
+        200: {"description": "Plan de venta encontrado"},
+        404: {"description": "Plan de venta no encontrado"}
+    }
+)
+async def obtener_plan_venta(
+    plan_id: str,
+    planes_service: PlanesVentaService = Depends(get_planes_venta_service)
+):
+    """
+    Obtiene toda la información de un plan de venta específico por su ID.
+    """
+    data = await planes_service.obtener_plan_venta(plan_id)
+    return data
+
+
+@planes_venta_router.put(
+    "/{plan_id}",
+    response_model=dict,
+    summary="Actualizar plan de venta",
+    description="Actualiza los datos de un plan de venta existente",
+    responses={
+        200: {"description": "Plan de venta actualizado exitosamente"},
+        404: {"description": "Plan de venta no encontrado"},
+        409: {"description": "Nombre ya existe en otro plan"},
+        422: {"description": "Error de validación en los datos"}
+    }
+)
+async def actualizar_plan_venta(
+    plan_id: str,
+    plan: ActualizarPlanVentaSchema,
+    planes_service: PlanesVentaService = Depends(get_planes_venta_service)
+):
+    """
+    Actualiza un plan de venta existente.
+
+    - Solo se actualizan los campos que se envíen en el request
+    - El nombre debe ser único si se actualiza
+    - Si se actualiza fecha_fin, debe ser posterior a fecha_inicio
+    """
+    data = await planes_service.actualizar_plan_venta(
+        plan_id,
+        plan.model_dump(exclude_unset=True)
+    )
+    return data
+
+
+@planes_venta_router.delete(
+    "/{plan_id}",
+    response_model=dict,
+    summary="Eliminar plan de venta",
+    description="Elimina un plan de venta del sistema",
+    responses={
+        200: {"description": "Plan de venta eliminado exitosamente"},
+        404: {"description": "Plan de venta no encontrado"}
+    }
+)
+async def eliminar_plan_venta(
+    plan_id: str,
+    planes_service: PlanesVentaService = Depends(get_planes_venta_service)
+):
+    """
+    Elimina un plan de venta específico por su ID.
+
+    NOTA: No se puede eliminar un plan que tenga vendedores asociados.
+    """
+    data = await planes_service.eliminar_plan_venta(plan_id)
+    return data

--- a/src/bff-web/router/vendedores.py
+++ b/src/bff-web/router/vendedores.py
@@ -16,7 +16,7 @@ vendedor_router = APIRouter()
 
 
 @vendedor_router.post(
-    "/",
+    "",
     response_model=dict,
     status_code=status.HTTP_201_CREATED,
     summary="Crear nuevo vendedor",
@@ -32,7 +32,8 @@ vendedor_router = APIRouter()
                             "id": "550e8400-e29b-41d4-a716-446655440000",
                             "nombre": "Juan Pérez",
                             "email": "juan.perez@medisupply.com",
-                            "zona_asignada": "Perú"
+                            "zona_asignada": "Perú",
+                            "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
                         }
                     }
                 }
@@ -53,15 +54,14 @@ async def crear_vendedor(
     - **documento_identidad**: Documento de identidad (obligatorio)
     - **email**: Email válido y único (obligatorio)
     - **zona_asignada**: Zona/país asignado (obligatorio)
-    - **plan_venta**: ID del plan de venta (opcional)
-    - **meta_venta**: Meta de ventas en monto monetario (opcional)
+    - **plan_venta_id**: UUID del plan de venta al que está asignado (obligatorio)
     """
     data = await vendedores_service.crear_vendedor(vendedor.model_dump())
     return data
 
 
 @vendedor_router.get(
-    "/",
+    "",
     response_model=dict,
     summary="Listar vendedores",
     description="Obtiene listado de vendedores con paginación",
@@ -77,7 +77,7 @@ async def crear_vendedor(
                                 "nombre": "Juan Pérez",
                                 "email": "juan.perez@medisupply.com",
                                 "zona_asignada": "Perú",
-                                "meta_venta": "50000.00"
+                                "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
                             }
                         ],
                         "total": 1,

--- a/src/bff-web/router/ventas.py
+++ b/src/bff-web/router/ventas.py
@@ -3,6 +3,7 @@ import logging
 
 from services.ventas_service import VentasService, get_ventas_service
 from router.vendedores import vendedor_router
+from router.planes_venta import planes_venta_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -15,4 +16,6 @@ def health_check(ventas_service: VentasService = Depends(get_ventas_service)):
 
 # Incluir el router de vendedores como sub-router
 ventas_router.include_router(vendedor_router, prefix="/vendedores", tags=["vendedores"])
-# TODO: router de planes de venta
+
+# Incluir el router de planes de venta como sub-router
+ventas_router.include_router(planes_venta_router, prefix="/planes", tags=["planes-venta"])

--- a/src/bff-web/schemas/plan_venta_schema.py
+++ b/src/bff-web/schemas/plan_venta_schema.py
@@ -1,0 +1,145 @@
+from pydantic import Field, BaseModel, field_validator
+from typing import Optional
+from datetime import datetime
+from decimal import Decimal
+
+from .vendedor_schema import ZonaAsignadaEnum
+
+
+class CrearPlanVentaSchema(BaseModel):
+    """
+    Schema para crear un nuevo plan de venta.
+
+    Valida todos los campos requeridos y opcionales al crear un plan.
+    """
+    nombre: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Nombre descriptivo del plan de venta (debe ser único)"
+    )
+    fecha_inicio: datetime = Field(
+        ...,
+        description="Fecha de inicio del plan de venta"
+    )
+    fecha_fin: datetime = Field(
+        ...,
+        description="Fecha de finalización del plan de venta"
+    )
+    descripcion: Optional[str] = Field(
+        None,
+        description="Descripción detallada del plan (opcional)"
+    )
+    meta_venta: Decimal = Field(
+        ...,
+        gt=0,
+        decimal_places=2,
+        description="Meta de ventas en monto monetario (debe ser mayor a 0)"
+    )
+    zona_asignada: Optional[ZonaAsignadaEnum] = Field(
+        None,
+        description="Zona geográfica asignada al plan (opcional)"
+    )
+
+    @field_validator('nombre')
+    @classmethod
+    def validate_nombre(cls, v: str) -> str:
+        """Valida que el nombre no sea una cadena vacía"""
+        if v.strip() == '':
+            raise ValueError('El nombre no puede estar vacío')
+        return v.strip()
+
+    @field_validator('descripcion')
+    @classmethod
+    def validate_descripcion(cls, v: Optional[str]) -> Optional[str]:
+        """Valida y limpia la descripción si se proporciona"""
+        if v is not None and v.strip() == '':
+            return None  # Convertir cadenas vacías a None
+        return v.strip() if v else None
+
+    @field_validator('fecha_fin')
+    @classmethod
+    def validate_fechas(cls, v: datetime, info) -> datetime:
+        """
+        Valida que la fecha_fin sea posterior a fecha_inicio.
+
+        Esta validación solo se ejecuta si fecha_inicio ya fue procesada.
+        """
+        if 'fecha_inicio' in info.data:
+            fecha_inicio = info.data['fecha_inicio']
+            if v <= fecha_inicio:
+                raise ValueError('La fecha_fin debe ser posterior a la fecha_inicio')
+        return v
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "nombre": "Plan Q1 2024 - Perú",
+                "fecha_inicio": "2024-01-01T00:00:00",
+                "fecha_fin": "2024-03-31T23:59:59",
+                "descripcion": "Plan de ventas del primer trimestre para la región de Perú",
+                "meta_venta": 100000.00,
+                "zona_asignada": "Perú"
+            }
+        }
+
+
+class ActualizarPlanVentaSchema(BaseModel):
+    """
+    Schema para actualizar un plan de venta existente.
+
+    Todos los campos son opcionales - solo se actualizan los enviados.
+    """
+    nombre: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=255,
+        description="Nombre descriptivo del plan de venta (debe ser único)"
+    )
+    fecha_inicio: Optional[datetime] = Field(
+        None,
+        description="Fecha de inicio del plan de venta"
+    )
+    fecha_fin: Optional[datetime] = Field(
+        None,
+        description="Fecha de finalización del plan de venta"
+    )
+    descripcion: Optional[str] = Field(
+        None,
+        description="Descripción detallada del plan"
+    )
+    meta_venta: Optional[Decimal] = Field(
+        None,
+        gt=0,
+        decimal_places=2,
+        description="Meta de ventas en monto monetario"
+    )
+    zona_asignada: Optional[ZonaAsignadaEnum] = Field(
+        None,
+        description="Zona geográfica asignada al plan"
+    )
+
+    @field_validator('nombre')
+    @classmethod
+    def validate_nombre(cls, v: Optional[str]) -> Optional[str]:
+        """Valida que el nombre no sea una cadena vacía"""
+        if v is not None and v.strip() == '':
+            raise ValueError('El nombre no puede estar vacío')
+        return v.strip() if v else v
+
+    @field_validator('descripcion')
+    @classmethod
+    def validate_descripcion(cls, v: Optional[str]) -> Optional[str]:
+        """Valida y limpia la descripción"""
+        if v is not None and v.strip() == '':
+            return None
+        return v.strip() if v else None
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "nombre": "Plan Q1 2024 - Perú (Actualizado)",
+                "meta_venta": 150000.00,
+                "descripcion": "Meta incrementada debido a buen desempeño"
+            }
+        }

--- a/src/bff-web/schemas/vendedor_schema.py
+++ b/src/bff-web/schemas/vendedor_schema.py
@@ -1,7 +1,7 @@
 from pydantic import Field, BaseModel, EmailStr, field_validator
 from typing import Optional
 from enum import Enum
-from decimal import Decimal
+from uuid import UUID
 
 
 class ZonaAsignadaEnum(str, Enum):
@@ -31,14 +31,9 @@ class CrearVendedorSchema(BaseModel):
         ...,
         description="Zona/país asignado al vendedor"
     )
-    plan_venta: Optional[str] = Field(
-        None,
-        description="ID del plan de venta asignado"
-    )
-    meta_venta: Optional[Decimal] = Field(
-        None,
-        ge=0,
-        description="Meta de ventas en monto monetario"
+    plan_venta_id: UUID = Field(
+        ...,
+        description="ID (UUID) del plan de venta al que está asignado el vendedor"
     )
 
     @field_validator('nombre')
@@ -64,8 +59,7 @@ class CrearVendedorSchema(BaseModel):
                 "documento_identidad": "12345678",
                 "email": "juan.perez@medisupply.com",
                 "zona_asignada": "Perú",
-                "plan_venta": "plan-123",
-                "meta_venta": 50000.00
+                "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
             }
         }
 
@@ -85,14 +79,9 @@ class ActualizarVendedorSchema(BaseModel):
         None,
         description="Zona/país asignado al vendedor"
     )
-    plan_venta: Optional[str] = Field(
+    plan_venta_id: Optional[UUID] = Field(
         None,
-        description="ID del plan de venta asignado"
-    )
-    meta_venta: Optional[Decimal] = Field(
-        None,
-        ge=0,
-        description="Meta de ventas en monto monetario"
+        description="ID (UUID) del plan de venta asignado"
     )
 
     @field_validator('nombre')
@@ -117,6 +106,6 @@ class ActualizarVendedorSchema(BaseModel):
                 "nombre": "Juan Pérez",
                 "email": "juan.nuevo@medisupply.com",
                 "zona_asignada": "Colombia",
-                "meta_venta": 75000.00
+                "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
             }
         }

--- a/src/bff-web/services/planes_venta_service.py
+++ b/src/bff-web/services/planes_venta_service.py
@@ -7,40 +7,30 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class VendedoresService:
-    """Service for communicating with the Ventas microservice (Vendedores endpoints)"""
+class PlanesVentaService:
+    """Service for communicating with the Ventas microservice (Planes de Venta endpoints)"""
 
     def __init__(self):
         self.base_url = os.getenv("VENTAS_SERVICE_URL", "http://ventas-service:3000")
         self.timeout = 30.0
 
-    def health_check(self) -> Dict[str, Any]:
-        """Check the health of the Ventas microservice"""
+    async def crear_plan_venta(self, plan_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new plan de venta via the ventas service"""
         try:
-            response = httpx.get(f"{self.base_url}/health", timeout=self.timeout)
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as e:
-            logger.error(f"Health check failed for Ventas microservice: {e}")
-            raise HTTPException(status_code=503, detail=f"Ventas service returned error: {e}")
-        except httpx.RequestError as e:
-            logger.error(f"Failed to connect to Ventas microservice: {e}")
-            raise HTTPException(status_code=503, detail=f"Cannot reach Ventas service: {e}")
-        except Exception as e:
-            logger.error(f"Unexpected error checking Ventas health: {e}")
-            raise HTTPException(status_code=500, detail=f"Unexpected error: {e}")
+            # Convert Decimal to float for JSON serialization
+            if 'meta_venta' in plan_data and plan_data['meta_venta'] is not None:
+                plan_data['meta_venta'] = float(plan_data['meta_venta'])
 
-    async def crear_vendedor(self, vendedor_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Create a new vendedor via the ventas service"""
-        try:
-            # Convert UUID to string for JSON serialization
-            if 'plan_venta_id' in vendedor_data and vendedor_data['plan_venta_id'] is not None:
-                vendedor_data['plan_venta_id'] = str(vendedor_data['plan_venta_id'])
+            # Convert datetime to ISO string
+            if 'fecha_inicio' in plan_data and plan_data['fecha_inicio'] is not None:
+                plan_data['fecha_inicio'] = plan_data['fecha_inicio'].isoformat()
+            if 'fecha_fin' in plan_data and plan_data['fecha_fin'] is not None:
+                plan_data['fecha_fin'] = plan_data['fecha_fin'].isoformat()
 
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.post(
-                    f"{self.base_url}/vendedores/",
-                    json=vendedor_data
+                    f"{self.base_url}/planes-venta/",
+                    json=plan_data
                 )
 
                 if response.status_code == 201:
@@ -61,21 +51,28 @@ class VendedoresService:
                 detail="Ventas service is not available"
             )
 
-    async def listar_vendedores(
+    async def listar_planes_venta(
         self,
         page: int = 1,
-        page_size: int = 20
+        page_size: int = 20,
+        nombre: Optional[str] = None,
+        zona_asignada: Optional[str] = None
     ) -> Dict[str, Any]:
-        """List vendedores with pagination"""
+        """List planes de venta with pagination and optional filters"""
         try:
             params = {
                 "page": page,
                 "page_size": page_size
             }
 
+            if nombre:
+                params["nombre"] = nombre
+            if zona_asignada:
+                params["zona_asignada"] = zona_asignada
+
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(
-                    f"{self.base_url}/vendedores/",
+                    f"{self.base_url}/planes-venta/",
                     params=params
                 )
 
@@ -93,18 +90,18 @@ class VendedoresService:
                 detail="Ventas service is not available"
             )
 
-    async def obtener_vendedor(self, vendedor_id: str) -> Dict[str, Any]:
-        """Get a specific vendedor by ID"""
+    async def obtener_plan_venta(self, plan_id: str) -> Dict[str, Any]:
+        """Get a specific plan de venta by ID"""
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(
-                    f"{self.base_url}/vendedores/{vendedor_id}"
+                    f"{self.base_url}/planes-venta/{plan_id}"
                 )
 
                 if response.status_code == 200:
                     return response.json()
                 elif response.status_code == 404:
-                    raise HTTPException(status_code=404, detail="Vendedor no encontrado")
+                    raise HTTPException(status_code=404, detail="Plan de venta no encontrado")
                 else:
                     raise HTTPException(
                         status_code=response.status_code,
@@ -117,55 +114,33 @@ class VendedoresService:
                 detail="Ventas service is not available"
             )
 
-    async def obtener_vendedor_por_email(self, email: str) -> Dict[str, Any]:
-        """Get a specific vendedor by email"""
-        try:
-            async with httpx.AsyncClient(timeout=self.timeout) as client:
-                response = await client.get(
-                    f"{self.base_url}/vendedores/by-email/{email}"
-                )
-
-                if response.status_code == 200:
-                    return response.json()
-                elif response.status_code == 404:
-                    raise HTTPException(
-                        status_code=404,
-                        detail=f"No existe un vendedor registrado con el email {email}. Por favor, contacte al administrador para crear su perfil de vendedor primero.",
-                    )
-                else:
-                    raise HTTPException(
-                        status_code=response.status_code,
-                        detail=f"Error from ventas service: {response.text}",
-                    )
-        except HTTPException:
-            raise
-        except httpx.RequestError as e:
-            logger.error(f"Error connecting to ventas service: {str(e)}")
-            raise HTTPException(
-                status_code=503, detail="Ventas service is not available"
-            )
-
-    async def actualizar_vendedor(
+    async def actualizar_plan_venta(
         self,
-        vendedor_id: str,
-        vendedor_data: Dict[str, Any]
+        plan_id: str,
+        plan_data: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Update an existing vendedor"""
+        """Update an existing plan de venta"""
         try:
-            # Convert UUID to string for JSON serialization
-            if 'plan_venta_id' in vendedor_data and vendedor_data['plan_venta_id'] is not None:
-                vendedor_data['plan_venta_id'] = str(vendedor_data['plan_venta_id'])
+            # Convert Decimal to float for JSON serialization
+            if 'meta_venta' in plan_data and plan_data['meta_venta'] is not None:
+                plan_data['meta_venta'] = float(plan_data['meta_venta'])
+
+            # Convert datetime to ISO string
+            if 'fecha_inicio' in plan_data and plan_data['fecha_inicio'] is not None:
+                plan_data['fecha_inicio'] = plan_data['fecha_inicio'].isoformat()
+            if 'fecha_fin' in plan_data and plan_data['fecha_fin'] is not None:
+                plan_data['fecha_fin'] = plan_data['fecha_fin'].isoformat()
 
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.put(
-                    f"{self.base_url}/vendedores/{vendedor_id}",
-                    json=vendedor_data
+                    f"{self.base_url}/planes-venta/{plan_id}",
+                    json=plan_data
                 )
 
                 if response.status_code == 200:
                     return response.json()
                 elif response.status_code == 404:
-                    raise HTTPException(status_code=404, detail="Vendedor no encontrado")
+                    raise HTTPException(status_code=404, detail="Plan de venta no encontrado")
                 elif response.status_code == 409:
                     raise HTTPException(status_code=409, detail=response.json())
                 elif response.status_code == 422:
@@ -182,7 +157,31 @@ class VendedoresService:
                 detail="Ventas service is not available"
             )
 
+    async def eliminar_plan_venta(self, plan_id: str) -> Dict[str, Any]:
+        """Delete a plan de venta"""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.delete(
+                    f"{self.base_url}/planes-venta/{plan_id}"
+                )
 
-def get_vendedores_service() -> VendedoresService:
-    """Dependency function to get vendedores service instance"""
-    return VendedoresService()
+                if response.status_code == 200:
+                    return response.json()
+                elif response.status_code == 404:
+                    raise HTTPException(status_code=404, detail="Plan de venta no encontrado")
+                else:
+                    raise HTTPException(
+                        status_code=response.status_code,
+                        detail=f"Error from ventas service: {response.text}"
+                    )
+        except httpx.RequestError as e:
+            logger.error(f"Error connecting to ventas service: {str(e)}")
+            raise HTTPException(
+                status_code=503,
+                detail="Ventas service is not available"
+            )
+
+
+def get_planes_venta_service() -> PlanesVentaService:
+    """Dependency function to get planes de venta service instance"""
+    return PlanesVentaService()

--- a/src/ventas/db/plan_venta_model.py
+++ b/src/ventas/db/plan_venta_model.py
@@ -1,0 +1,85 @@
+from sqlalchemy import Column, DateTime, String, Numeric, Text
+from sqlalchemy.dialects.postgresql import UUID
+from datetime import datetime, timezone
+import uuid
+from .database import Base
+
+
+class PlanVenta(Base):
+    """
+    Modelo de Plan de Venta.
+
+    Un plan de venta define objetivos y metas comerciales para vendedores
+    en períodos específicos y zonas geográficas determinadas.
+
+    Attributes:
+        id: Identificador único UUID
+        fecha_creacion: Timestamp de creación del registro
+        fecha_actualizacion: Timestamp de última actualización
+        nombre: Nombre descriptivo del plan
+        fecha_inicio: Fecha de inicio del plan
+        fecha_fin: Fecha de finalización del plan
+        descripcion: Descripción detallada opcional (texto largo)
+        meta_venta: Meta monetaria del plan (Decimal con 2 decimales)
+        zona_asignada: Zona geográfica asignada (opcional)
+    """
+    __tablename__ = "planes_venta"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    fecha_creacion = Column(DateTime, default=datetime.now)
+    fecha_actualizacion = Column(DateTime, default=datetime.now)
+    nombre = Column(String(255), nullable=False, unique=True)
+    fecha_inicio = Column(DateTime, nullable=False)
+    fecha_fin = Column(DateTime, nullable=False)
+    descripcion = Column(Text, nullable=True)
+    meta_venta = Column(Numeric(12, 2), nullable=False)
+    zona_asignada = Column(String, nullable=True)
+
+    def __init__(
+        self,
+        nombre,
+        fecha_inicio,
+        fecha_fin,
+        meta_venta,
+        descripcion=None,
+        zona_asignada=None
+    ):
+        """
+        Inicializa un nuevo Plan de Venta.
+
+        Args:
+            nombre: Nombre del plan
+            fecha_inicio: Fecha de inicio del plan
+            fecha_fin: Fecha de finalización del plan
+            meta_venta: Meta monetaria a alcanzar
+            descripcion: Descripción opcional del plan
+            zona_asignada: Zona geográfica opcional
+        """
+        now = datetime.now(timezone.utc)
+        self.fecha_creacion = now
+        self.fecha_actualizacion = now
+        self.nombre = nombre
+        self.fecha_inicio = fecha_inicio
+        self.fecha_fin = fecha_fin
+        self.descripcion = descripcion
+        self.meta_venta = meta_venta
+        self.zona_asignada = zona_asignada
+
+    def to_dict(self):
+        """
+        Convierte la instancia de PlanVenta a diccionario.
+
+        Returns:
+            Dict con todos los campos del plan de venta
+        """
+        return {
+            "id": str(self.id),
+            "fecha_creacion": self.fecha_creacion.isoformat() if self.fecha_creacion else None,
+            "fecha_actualizacion": self.fecha_actualizacion.isoformat() if self.fecha_actualizacion else None,
+            "nombre": self.nombre,
+            "fecha_inicio": self.fecha_inicio.isoformat() if self.fecha_inicio else None,
+            "fecha_fin": self.fecha_fin.isoformat() if self.fecha_fin else None,
+            "descripcion": self.descripcion,
+            "meta_venta": str(self.meta_venta) if self.meta_venta else None,
+            "zona_asignada": self.zona_asignada,
+        }

--- a/src/ventas/db/vendedor_model.py
+++ b/src/ventas/db/vendedor_model.py
@@ -31,9 +31,14 @@ class Vendedor(Base):
         self.zona_asignada = zona_asignada
         self.plan_venta_id = plan_venta_id
 
-    def to_dict(self):
-        """Convert Vendedor instance to dictionary"""
-        return {
+    def to_dict(self, include_plan_venta=False):
+        """
+        Convert Vendedor instance to dictionary
+
+        Args:
+            include_plan_venta: Si es True, incluye información expandida del plan de venta
+        """
+        result = {
             "id": str(self.id),
             "fecha_creacion": self.fecha_creacion.isoformat() if self.fecha_creacion else None,
             "fecha_actualizacion": self.fecha_actualizacion.isoformat() if self.fecha_actualizacion else None,
@@ -43,3 +48,16 @@ class Vendedor(Base):
             "zona_asignada": self.zona_asignada,
             "plan_venta_id": str(self.plan_venta_id),
         }
+
+        # Incluir información del plan de venta si se solicita
+        if include_plan_venta and self.plan_venta:
+            result["plan_venta"] = {
+                "id": str(self.plan_venta.id),
+                "nombre": self.plan_venta.nombre,
+                "fecha_inicio": self.plan_venta.fecha_inicio.isoformat() if self.plan_venta.fecha_inicio else None,
+                "fecha_fin": self.plan_venta.fecha_fin.isoformat() if self.plan_venta.fecha_fin else None,
+                "meta_venta": str(self.plan_venta.meta_venta) if self.plan_venta.meta_venta else None,
+                "zona_asignada": self.plan_venta.zona_asignada,
+            }
+
+        return result

--- a/src/ventas/db/vendedor_model.py
+++ b/src/ventas/db/vendedor_model.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, DateTime, String, Numeric
+from sqlalchemy import Column, DateTime, String, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 import uuid
 from .database import Base
@@ -15,10 +16,12 @@ class Vendedor(Base):
     documento_identidad = Column(String, nullable=True)
     email = Column(String, nullable=False, unique=True)
     zona_asignada = Column(String, nullable=False)
-    plan_venta = Column(String, nullable=False)
-    meta_venta = Column(Numeric(12, 2), nullable=True)
+    plan_venta_id = Column(UUID(as_uuid=True), ForeignKey('planes_venta.id'), nullable=False)
 
-    def __init__(self, nombre, documento_identidad, email, zona_asignada, plan_venta, meta_venta=None):
+    # Relación con PlanVenta
+    plan_venta = relationship("PlanVenta", foreign_keys=[plan_venta_id])
+
+    def __init__(self, nombre, documento_identidad, email, zona_asignada, plan_venta_id):
         now = datetime.now(timezone.utc)
         self.fecha_creacion = now
         self.fecha_actualizacion = now
@@ -26,8 +29,7 @@ class Vendedor(Base):
         self.documento_identidad = documento_identidad
         self.email = email
         self.zona_asignada = zona_asignada
-        self.plan_venta = plan_venta
-        self.meta_venta = meta_venta
+        self.plan_venta_id = plan_venta_id
 
     def to_dict(self):
         """Convert Vendedor instance to dictionary"""
@@ -39,6 +41,5 @@ class Vendedor(Base):
             "documento_identidad": self.documento_identidad,
             "email": self.email,
             "zona_asignada": self.zona_asignada,
-            "plan_venta": self.plan_venta,
-            "meta_venta": str(self.meta_venta) if self.meta_venta else None,
+            "plan_venta_id": str(self.plan_venta_id),
         }

--- a/src/ventas/main.py
+++ b/src/ventas/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI, Depends, HTTPException
 from services.health_service import HealthService, get_health_service
 from router.vendedor_router import vendedor_router
+from router.plan_venta_router import plan_venta_router
 from db.database import engine, Base
-from db.vendedor_model import Vendedor  # Importar el modelo para registrarlo con Base
+from db.vendedor_model import Vendedor # Importar el modelo para registrarlo con Base
+from db.plan_venta_model import PlanVenta # Importar el modelo para registrarlo con Base
 import logging
 
 logging.basicConfig(level=logging.DEBUG, force=True)
@@ -10,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="MediSupply - Ventas Service",
-    description="API para la gestión de vendedores en MediSupply",
+    description="API para la gestión de ventas en MediSupply",
     version="1.0.0",
     docs_url="/docs",
     redoc_url="/redoc"
@@ -25,6 +27,13 @@ app.include_router(
     vendedor_router,
     prefix="/vendedores",
     tags=["Vendedores"]
+)
+
+# Registrar el router de planes de venta
+app.include_router(
+    plan_venta_router,
+    prefix="/planes-venta",
+    tags=["Planes de Venta"]
 )
 
 

--- a/src/ventas/router/plan_venta_router.py
+++ b/src/ventas/router/plan_venta_router.py
@@ -1,0 +1,212 @@
+from fastapi import APIRouter, Depends, Query, status
+from typing import Optional
+import logging
+
+from services.plan_venta_service import PlanVentaService, get_plan_venta_service
+from schemas.plan_venta_schema import (
+    CrearPlanVentaSchema,
+    ActualizarPlanVentaSchema,
+)
+from schemas.vendedor_schema import ZonaAsignadaEnum
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+plan_venta_router = APIRouter()
+
+
+@plan_venta_router.post(
+    "/",
+    response_model=dict,
+    status_code=status.HTTP_201_CREATED,
+    summary="Crear nuevo plan de venta",
+    description="Crea un nuevo plan de venta en el sistema con validación de fechas, meta y nombre único",
+    responses={
+        201: {
+            "description": "Plan de venta creado exitosamente",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "message": "Creación exitosa",
+                        "data": {
+                            "id": "550e8400-e29b-41d4-a716-446655440000",
+                            "nombre": "Plan Q1 2024 - Perú",
+                            "fecha_inicio": "2024-01-01T00:00:00",
+                            "fecha_fin": "2024-03-31T23:59:59",
+                            "descripcion": "Plan trimestral para Perú",
+                            "meta_venta": "100000.00",
+                            "zona_asignada": "Perú"
+                        }
+                    }
+                }
+            }
+        },
+        400: {"description": "Datos inválidos (ej: fecha_fin antes de fecha_inicio)"},
+        409: {"description": "El nombre del plan ya existe"},
+        422: {"description": "Error de validación en los datos"}
+    }
+)
+async def crear_plan_venta(
+    plan: CrearPlanVentaSchema,
+    plan_service: PlanVentaService = Depends(get_plan_venta_service)
+):
+    """
+    Crea un nuevo plan de venta con los siguientes datos:
+
+    - **nombre**: Nombre descriptivo del plan (obligatorio, único)
+    - **fecha_inicio**: Fecha de inicio del plan (obligatorio)
+    - **fecha_fin**: Fecha de finalización (obligatorio, debe ser posterior a fecha_inicio)
+    - **descripcion**: Descripción detallada del plan (opcional)
+    - **meta_venta**: Meta de ventas en monto monetario (obligatorio, debe ser > 0)
+    - **zona_asignada**: Zona geográfica asignada (opcional)
+    """
+    data = plan_service.crear_plan_venta(plan)
+    return {
+        "message": "Creación exitosa",
+        "data": data
+    }
+
+
+@plan_venta_router.get(
+    "/",
+    response_model=dict,
+    summary="Listar planes de venta",
+    description="Obtiene listado de planes de venta con paginación y filtros opcionales",
+    responses={
+        200: {
+            "description": "Lista de planes de venta obtenida exitosamente",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "data": [
+                            {
+                                "id": "550e8400-e29b-41d4-a716-446655440000",
+                                "nombre": "Plan Q1 2024 - Perú",
+                                "fecha_inicio": "2024-01-01T00:00:00",
+                                "fecha_fin": "2024-03-31T23:59:59",
+                                "meta_venta": "100000.00",
+                                "zona_asignada": "Perú"
+                            }
+                        ],
+                        "total": 1,
+                        "page": 1,
+                        "page_size": 20,
+                        "total_pages": 1
+                    }
+                }
+            }
+        }
+    }
+)
+async def listar_planes_venta(
+    page: int = Query(1, ge=1, description="Número de página"),
+    page_size: int = Query(20, ge=1, le=100, description="Tamaño de página (máximo 100)"),
+    zona_asignada: Optional[ZonaAsignadaEnum] = Query(None, description="Filtrar por zona específica"),
+    plan_service: PlanVentaService = Depends(get_plan_venta_service)
+):
+    """
+    Lista todos los planes de venta con opciones de:
+
+    - **Paginación**: Con page (número de página) y page_size (tamaño)
+    - **Filtrado por zona**: Opcional, filtra por zona geográfica específica
+    - **Ordenamiento**: Por fecha de inicio (más recientes primero)
+    """
+    skip = (page - 1) * page_size
+
+    planes = plan_service.listar_planes_venta(
+        skip=skip,
+        limit=page_size,
+        zona_asignada=zona_asignada.value if zona_asignada else None
+    )
+
+    total = plan_service.contar_planes_venta(
+        zona_asignada=zona_asignada.value if zona_asignada else None
+    )
+
+    return {
+        "data": planes,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "total_pages": (total + page_size - 1) // page_size if total > 0 else 0
+    }
+
+
+@plan_venta_router.get(
+    "/{plan_id}",
+    response_model=dict,
+    summary="Obtener plan de venta por ID",
+    description="Obtiene los detalles completos de un plan de venta específico",
+    responses={
+        200: {"description": "Plan de venta encontrado"},
+        404: {"description": "Plan de venta no encontrado"}
+    }
+)
+async def obtener_plan_venta(
+    plan_id: str,
+    plan_service: PlanVentaService = Depends(get_plan_venta_service)
+):
+    """
+    Obtiene toda la información de un plan de venta específico por su ID.
+    """
+    data = plan_service.obtener_plan_venta(plan_id)
+    return {
+        "data": data
+    }
+
+
+@plan_venta_router.put(
+    "/{plan_id}",
+    response_model=dict,
+    summary="Actualizar plan de venta",
+    description="Actualiza los datos de un plan de venta existente",
+    responses={
+        200: {"description": "Plan de venta actualizado exitosamente"},
+        404: {"description": "Plan de venta no encontrado"},
+        400: {"description": "Fechas inválidas"},
+        409: {"description": "El nombre ya existe en otro plan"},
+        422: {"description": "Error de validación en los datos"}
+    }
+)
+async def actualizar_plan_venta(
+    plan_id: str,
+    plan: ActualizarPlanVentaSchema,
+    plan_service: PlanVentaService = Depends(get_plan_venta_service)
+):
+    """
+    Actualiza un plan de venta existente.
+
+    - Solo se actualizan los campos que se envíen en el request
+    - El nombre debe ser único si se actualiza
+    - Si se actualizan fechas, se valida que fecha_fin > fecha_inicio
+    - La meta_venta debe ser positiva si se actualiza
+    """
+    data = plan_service.actualizar_plan_venta(plan_id, plan)
+    return {
+        "message": "Plan de venta actualizado exitosamente",
+        "data": data
+    }
+
+
+@plan_venta_router.delete(
+    "/{plan_id}",
+    response_model=dict,
+    status_code=status.HTTP_200_OK,
+    summary="Eliminar plan de venta",
+    description="Elimina un plan de venta del sistema",
+    responses={
+        200: {"description": "Plan de venta eliminado exitosamente"},
+        404: {"description": "Plan de venta no encontrado"}
+    }
+)
+async def eliminar_plan_venta(
+    plan_id: str,
+    plan_service: PlanVentaService = Depends(get_plan_venta_service)
+):
+    """
+    Elimina un plan de venta del sistema por su ID.
+
+    **Advertencia**: Esta acción es permanente y no se puede deshacer.
+    """
+    result = plan_service.eliminar_plan_venta(plan_id)
+    return result

--- a/src/ventas/router/vendedor_router.py
+++ b/src/ventas/router/vendedor_router.py
@@ -50,11 +50,10 @@ async def crear_vendedor(
     Crea un nuevo vendedor con los siguientes datos:
 
     - **nombre**: Nombre completo del vendedor (obligatorio)
-    - **documento_identidad**: Documento de identidad (opcional)
+    - **documento_identidad**: Documento de identidad (obligatorio)
     - **email**: Email válido y único (obligatorio)
     - **zona_asignada**: Zona/país asignado (obligatorio)
-    - **plan_venta**: ID del plan de venta (opcional)
-    - **meta_venta**: Meta de ventas en monto monetario (opcional)
+    - **plan_venta_id**: UUID del plan de venta al que está asignado (obligatorio)
     """
     data = vendedor_service.crear_vendedor(vendedor)
     return {
@@ -80,7 +79,7 @@ async def crear_vendedor(
                                 "nombre": "Juan Pérez",
                                 "email": "juan.perez@medisupply.com",
                                 "zona_asignada": "Perú",
-                                "meta_venta": "50000.00"
+                                "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
                             }
                         ],
                         "total": 1,

--- a/src/ventas/schemas/plan_venta_schema.py
+++ b/src/ventas/schemas/plan_venta_schema.py
@@ -1,0 +1,145 @@
+from pydantic import Field, BaseModel, field_validator
+from typing import Optional
+from datetime import datetime
+from decimal import Decimal
+
+from .vendedor_schema import ZonaAsignadaEnum
+
+
+class CrearPlanVentaSchema(BaseModel):
+    """
+    Schema para crear un nuevo plan de venta.
+
+    Valida todos los campos requeridos y opcionales al crear un plan.
+    """
+    nombre: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Nombre descriptivo del plan de venta (debe ser único)"
+    )
+    fecha_inicio: datetime = Field(
+        ...,
+        description="Fecha de inicio del plan de venta"
+    )
+    fecha_fin: datetime = Field(
+        ...,
+        description="Fecha de finalización del plan de venta"
+    )
+    descripcion: Optional[str] = Field(
+        None,
+        description="Descripción detallada del plan (opcional)"
+    )
+    meta_venta: Decimal = Field(
+        ...,
+        gt=0,
+        decimal_places=2,
+        description="Meta de ventas en monto monetario (debe ser mayor a 0)"
+    )
+    zona_asignada: Optional[ZonaAsignadaEnum] = Field(
+        None,
+        description="Zona geográfica asignada al plan (opcional)"
+    )
+
+    @field_validator('nombre')
+    @classmethod
+    def validate_nombre(cls, v: str) -> str:
+        """Valida que el nombre no sea una cadena vacía"""
+        if v.strip() == '':
+            raise ValueError('El nombre no puede estar vacío')
+        return v.strip()
+
+    @field_validator('descripcion')
+    @classmethod
+    def validate_descripcion(cls, v: Optional[str]) -> Optional[str]:
+        """Valida y limpia la descripción si se proporciona"""
+        if v is not None and v.strip() == '':
+            return None  # Convertir cadenas vacías a None
+        return v.strip() if v else None
+
+    @field_validator('fecha_fin')
+    @classmethod
+    def validate_fechas(cls, v: datetime, info) -> datetime:
+        """
+        Valida que la fecha_fin sea posterior a fecha_inicio.
+
+        Esta validación solo se ejecuta si fecha_inicio ya fue procesada.
+        """
+        if 'fecha_inicio' in info.data:
+            fecha_inicio = info.data['fecha_inicio']
+            if v <= fecha_inicio:
+                raise ValueError('La fecha_fin debe ser posterior a la fecha_inicio')
+        return v
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "nombre": "Plan Q1 2024 - Perú",
+                "fecha_inicio": "2024-01-01T00:00:00",
+                "fecha_fin": "2024-03-31T23:59:59",
+                "descripcion": "Plan de ventas del primer trimestre para la región de Perú",
+                "meta_venta": 100000.00,
+                "zona_asignada": "Perú"
+            }
+        }
+
+
+class ActualizarPlanVentaSchema(BaseModel):
+    """
+    Schema para actualizar un plan de venta existente.
+
+    Todos los campos son opcionales - solo se actualizan los enviados.
+    """
+    nombre: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=255,
+        description="Nombre descriptivo del plan de venta (debe ser único)"
+    )
+    fecha_inicio: Optional[datetime] = Field(
+        None,
+        description="Fecha de inicio del plan de venta"
+    )
+    fecha_fin: Optional[datetime] = Field(
+        None,
+        description="Fecha de finalización del plan de venta"
+    )
+    descripcion: Optional[str] = Field(
+        None,
+        description="Descripción detallada del plan"
+    )
+    meta_venta: Optional[Decimal] = Field(
+        None,
+        gt=0,
+        decimal_places=2,
+        description="Meta de ventas en monto monetario"
+    )
+    zona_asignada: Optional[ZonaAsignadaEnum] = Field(
+        None,
+        description="Zona geográfica asignada al plan"
+    )
+
+    @field_validator('nombre')
+    @classmethod
+    def validate_nombre(cls, v: Optional[str]) -> Optional[str]:
+        """Valida que el nombre no sea una cadena vacía"""
+        if v is not None and v.strip() == '':
+            raise ValueError('El nombre no puede estar vacío')
+        return v.strip() if v else v
+
+    @field_validator('descripcion')
+    @classmethod
+    def validate_descripcion(cls, v: Optional[str]) -> Optional[str]:
+        """Valida y limpia la descripción"""
+        if v is not None and v.strip() == '':
+            return None
+        return v.strip() if v else None
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "nombre": "Plan Q1 2024 - Perú (Actualizado)",
+                "meta_venta": 150000.00,
+                "descripcion": "Meta incrementada debido a buen desempeño"
+            }
+        }

--- a/src/ventas/schemas/vendedor_schema.py
+++ b/src/ventas/schemas/vendedor_schema.py
@@ -1,7 +1,7 @@
 from pydantic import Field, BaseModel, EmailStr, field_validator
 from typing import Optional
 from enum import Enum
-from decimal import Decimal
+from uuid import UUID
 
 
 class ZonaAsignadaEnum(str, Enum):
@@ -31,14 +31,9 @@ class CrearVendedorSchema(BaseModel):
         ...,
         description="Zona/país asignado al vendedor"
     )
-    plan_venta: Optional[str] = Field(
-        None,
-        description="ID del plan de venta asignado"
-    )
-    meta_venta: Optional[Decimal] = Field(
-        None,
-        ge=0,
-        description="Meta de ventas en monto monetario"
+    plan_venta_id: UUID = Field(
+        ...,
+        description="ID (UUID) del plan de venta al que está asignado el vendedor"
     )
 
     @field_validator('nombre')
@@ -64,8 +59,7 @@ class CrearVendedorSchema(BaseModel):
                 "documento_identidad": "12345678",
                 "email": "juan.perez@medisupply.com",
                 "zona_asignada": "Perú",
-                "plan_venta": "plan-123",
-                "meta_venta": 50000.00
+                "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
             }
         }
 
@@ -85,14 +79,9 @@ class ActualizarVendedorSchema(BaseModel):
         None,
         description="Zona/país asignado al vendedor"
     )
-    plan_venta: Optional[str] = Field(
+    plan_venta_id: Optional[UUID] = Field(
         None,
-        description="ID del plan de venta asignado"
-    )
-    meta_venta: Optional[Decimal] = Field(
-        None,
-        ge=0,
-        description="Meta de ventas en monto monetario"
+        description="ID (UUID) del plan de venta asignado"
     )
 
     @field_validator('nombre')
@@ -117,6 +106,6 @@ class ActualizarVendedorSchema(BaseModel):
                 "nombre": "Juan Pérez",
                 "email": "juan.nuevo@medisupply.com",
                 "zona_asignada": "Colombia",
-                "meta_venta": 75000.00
+                "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
             }
         }

--- a/src/ventas/services/plan_venta_service.py
+++ b/src/ventas/services/plan_venta_service.py
@@ -1,0 +1,353 @@
+from typing import Dict, Any, List, Optional
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from fastapi import Depends, HTTPException
+from http import HTTPStatus
+from datetime import datetime, timezone
+import logging
+
+from db.database import get_db
+from db.plan_venta_model import PlanVenta
+from schemas.plan_venta_schema import (
+    CrearPlanVentaSchema,
+    ActualizarPlanVentaSchema,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PlanVentaService:
+    """
+    Servicio de negocio para la gestión de planes de venta.
+
+    Responsabilidades:
+    - CRUD completo de planes de venta
+    - Validación de rangos de fechas
+    - Validación de solapamiento de planes (opcional)
+    - Manejo de errores con HTTPException
+    """
+
+    def __init__(self, db: Session = Depends(get_db)):
+        """
+        Inicializa el servicio con conexión a base de datos.
+
+        Args:
+            db: Sesión de SQLAlchemy inyectada por dependencia
+        """
+        self.db = db
+
+    def crear_plan_venta(self, plan_data: CrearPlanVentaSchema) -> Dict[str, Any]:
+        """
+        Crea un nuevo plan de venta en el sistema.
+
+        Validaciones:
+        1. El nombre debe ser único
+        2. Las fechas ya vienen validadas por Pydantic (fecha_fin > fecha_inicio)
+        3. meta_venta debe ser positiva (validado por Pydantic)
+
+        Args:
+            plan_data: Datos del plan de venta a crear
+
+        Returns:
+            Dict con los datos del plan creado
+
+        Raises:
+            HTTPException 409: Si el nombre ya existe
+            HTTPException 500: Error interno del servidor
+        """
+        try:
+            # Verificar si el nombre ya existe
+            existing_by_nombre = self.db.query(PlanVenta).filter(
+                PlanVenta.nombre == plan_data.nombre
+            ).first()
+
+            if existing_by_nombre:
+                raise HTTPException(
+                    status_code=HTTPStatus.CONFLICT,
+                    detail=f"Ya existe un plan de venta con el nombre '{plan_data.nombre}'."
+                )
+
+            # Crear nuevo plan de venta
+            nuevo_plan = PlanVenta(
+                nombre=plan_data.nombre,
+                fecha_inicio=plan_data.fecha_inicio,
+                fecha_fin=plan_data.fecha_fin,
+                descripcion=plan_data.descripcion,
+                meta_venta=plan_data.meta_venta,
+                zona_asignada=plan_data.zona_asignada.value if plan_data.zona_asignada else None
+            )
+
+            self.db.add(nuevo_plan)
+            self.db.commit()
+            self.db.refresh(nuevo_plan)
+
+            logger.info(f"Plan de venta creado exitosamente: {nuevo_plan.id}")
+
+            return nuevo_plan.to_dict()
+
+        except HTTPException:
+            raise
+        except IntegrityError as e:
+            self.db.rollback()
+            logger.error(f"Error de integridad al crear plan de venta: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.CONFLICT,
+                detail="El nombre del plan de venta ya existe en el sistema."
+            )
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Error al crear plan de venta: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al crear el plan de venta."
+            )
+
+    def obtener_plan_venta(self, plan_id: str) -> Dict[str, Any]:
+        """
+        Obtiene un plan de venta por su ID.
+
+        Args:
+            plan_id: UUID del plan de venta
+
+        Returns:
+            Dict con los datos del plan
+
+        Raises:
+            HTTPException 404: Plan de venta no encontrado
+            HTTPException 500: Error interno
+        """
+        try:
+            plan = self.db.query(PlanVenta).filter(
+                PlanVenta.id == plan_id
+            ).first()
+
+            if not plan:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"Plan de venta con ID {plan_id} no encontrado."
+                )
+
+            return plan.to_dict()
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error al obtener plan de venta {plan_id}: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al obtener el plan de venta."
+            )
+
+    def listar_planes_venta(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        zona_asignada: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Lista todos los planes de venta con filtros opcionales.
+
+        Args:
+            skip: Número de registros a saltar (paginación)
+            limit: Número máximo de registros a retornar
+            zona_asignada: Filtrar por zona específica (opcional)
+
+        Returns:
+            Lista de planes de venta
+        """
+        try:
+            query = self.db.query(PlanVenta)
+
+            # Filtro por zona
+            if zona_asignada:
+                query = query.filter(PlanVenta.zona_asignada == zona_asignada)
+
+            # Ordenar por fecha de inicio descendente (más recientes primero)
+            query = query.order_by(PlanVenta.fecha_inicio.desc())
+
+            planes = query.offset(skip).limit(limit).all()
+
+            return [plan.to_dict() for plan in planes]
+
+        except Exception as e:
+            logger.error(f"Error al listar planes de venta: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al listar planes de venta."
+            )
+
+    def actualizar_plan_venta(
+        self,
+        plan_id: str,
+        plan_data: ActualizarPlanVentaSchema
+    ) -> Dict[str, Any]:
+        """
+        Actualiza un plan de venta existente.
+
+        Pasos:
+        1. Verifica que el plan exista
+        2. Si se actualiza el nombre, verifica que no exista en otro plan
+        3. Si se actualizan fechas, valida la coherencia
+        4. Actualiza solo los campos proporcionados
+
+        Args:
+            plan_id: ID del plan de venta a actualizar
+            plan_data: Datos a actualizar
+
+        Returns:
+            Dict con los datos del plan actualizado
+
+        Raises:
+            HTTPException 404: Plan no encontrado
+            HTTPException 409: Nombre ya existe en otro plan
+            HTTPException 400: Fechas inválidas
+        """
+        try:
+            plan = self.db.query(PlanVenta).filter(
+                PlanVenta.id == plan_id
+            ).first()
+
+            if not plan:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"Plan de venta con ID {plan_id} no encontrado."
+                )
+
+            # Verificar si el nuevo nombre ya existe en otro plan
+            if plan_data.nombre and plan_data.nombre != plan.nombre:
+                existing_by_nombre = self.db.query(PlanVenta).filter(
+                    PlanVenta.nombre == plan_data.nombre,
+                    PlanVenta.id != plan_id
+                ).first()
+
+                if existing_by_nombre:
+                    raise HTTPException(
+                        status_code=HTTPStatus.CONFLICT,
+                        detail=f"Ya existe otro plan de venta con el nombre '{plan_data.nombre}'."
+                    )
+
+            # Actualizar solo los campos proporcionados
+            update_data = plan_data.model_dump(exclude_unset=True)
+
+            # Validar fechas si se actualizan ambas o alguna
+            fecha_inicio_nueva = update_data.get('fecha_inicio', plan.fecha_inicio)
+            fecha_fin_nueva = update_data.get('fecha_fin', plan.fecha_fin)
+
+            if fecha_fin_nueva <= fecha_inicio_nueva:
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    detail="La fecha_fin debe ser posterior a la fecha_inicio."
+                )
+
+            for field, value in update_data.items():
+                if value is not None:
+                    # Convertir enums a sus valores
+                    if hasattr(value, 'value'):
+                        value = value.value
+                    setattr(plan, field, value)
+
+            plan.fecha_actualizacion = datetime.now(timezone.utc)
+
+            self.db.commit()
+            self.db.refresh(plan)
+
+            logger.info(f"Plan de venta actualizado exitosamente: {plan_id}")
+
+            return plan.to_dict()
+
+        except HTTPException:
+            raise
+        except IntegrityError as e:
+            self.db.rollback()
+            logger.error(f"Error de integridad al actualizar plan de venta: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.CONFLICT,
+                detail="El nombre del plan de venta ya existe en otro plan."
+            )
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Error al actualizar plan de venta {plan_id}: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al actualizar el plan de venta."
+            )
+
+    def eliminar_plan_venta(self, plan_id: str) -> Dict[str, str]:
+        """
+        Elimina un plan de venta del sistema.
+
+        Args:
+            plan_id: ID del plan de venta a eliminar
+
+        Returns:
+            Dict con mensaje de confirmación
+
+        Raises:
+            HTTPException 404: Plan no encontrado
+            HTTPException 500: Error interno
+        """
+        try:
+            plan = self.db.query(PlanVenta).filter(
+                PlanVenta.id == plan_id
+            ).first()
+
+            if not plan:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"Plan de venta con ID {plan_id} no encontrado."
+                )
+
+            self.db.delete(plan)
+            self.db.commit()
+
+            logger.info(f"Plan de venta eliminado exitosamente: {plan_id}")
+
+            return {"message": f"Plan de venta {plan_id} eliminado exitosamente"}
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            self.db.rollback()
+            logger.error(f"Error al eliminar plan de venta {plan_id}: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al eliminar el plan de venta."
+            )
+
+    def contar_planes_venta(
+        self,
+        zona_asignada: Optional[str] = None
+    ) -> int:
+        """
+        Cuenta el número total de planes de venta con filtros opcionales.
+
+        Args:
+            zona_asignada: Filtrar por zona específica
+
+        Returns:
+            Número total de planes de venta
+        """
+        try:
+            query = self.db.query(PlanVenta)
+
+            # Aplicar los mismos filtros que listar_planes_venta
+            if zona_asignada:
+                query = query.filter(PlanVenta.zona_asignada == zona_asignada)
+
+            return query.count()
+
+        except Exception as e:
+            logger.error(f"Error al contar planes de venta: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al contar planes de venta."
+            )
+
+
+def get_plan_venta_service(db: Session = Depends(get_db)) -> PlanVentaService:
+    """
+    Función de dependencia para obtener una instancia del servicio de planes de venta.
+
+    Esta función se usa en los routers con Depends() para inyección de dependencias.
+    """
+    return PlanVentaService(db)

--- a/src/ventas/services/vendedor_service.py
+++ b/src/ventas/services/vendedor_service.py
@@ -9,6 +9,7 @@ import logging
 
 from db.database import get_db
 from db.vendedor_model import Vendedor
+from db.plan_venta_model import PlanVenta
 from schemas.vendedor_schema import (
     CrearVendedorSchema,
     ActualizarVendedorSchema,
@@ -42,7 +43,8 @@ class VendedorService:
 
         Pasos:
         1. Verifica que el email no exista
-        2. Crea el vendedor en la BD
+        2. Valida que el plan de venta exista
+        3. Crea el vendedor en la BD
 
         Args:
             vendedor_data: Datos del vendedor a crear
@@ -51,6 +53,7 @@ class VendedorService:
             Dict con los datos del vendedor creado
 
         Raises:
+            HTTPException 404: Si el plan de venta no existe
             HTTPException 409: Si el email ya existe
             HTTPException 500: Error interno del servidor
         """
@@ -66,14 +69,24 @@ class VendedorService:
                     detail=f"El email {vendedor_data.email} ya está registrado en el sistema."
                 )
 
+            # Validar que el plan de venta exista
+            plan_existe = self.db.query(PlanVenta).filter(
+                PlanVenta.id == vendedor_data.plan_venta_id
+            ).first()
+
+            if not plan_existe:
+                raise HTTPException(
+                    status_code=HTTPStatus.NOT_FOUND,
+                    detail=f"El plan de venta con ID {vendedor_data.plan_venta_id} no existe."
+                )
+
             # Crear nuevo vendedor
             nuevo_vendedor = Vendedor(
                 nombre=vendedor_data.nombre,
                 documento_identidad=vendedor_data.documento_identidad,
                 email=vendedor_data.email,
                 zona_asignada=vendedor_data.zona_asignada.value,
-                plan_venta=vendedor_data.plan_venta,
-                meta_venta=vendedor_data.meta_venta
+                plan_venta_id=vendedor_data.plan_venta_id
             )
 
             self.db.add(nuevo_vendedor)
@@ -215,7 +228,8 @@ class VendedorService:
         Pasos:
         1. Verifica que el vendedor exista
         2. Si se actualiza el email, verifica que no exista en otro vendedor
-        3. Actualiza solo los campos proporcionados
+        3. Si se actualiza el plan de venta, valida que exista
+        4. Actualiza solo los campos proporcionados
 
         Args:
             vendedor_id: ID del vendedor a actualizar
@@ -225,7 +239,7 @@ class VendedorService:
             Dict con los datos del vendedor actualizado
 
         Raises:
-            HTTPException 404: Vendedor no encontrado
+            HTTPException 404: Vendedor o plan de venta no encontrado
             HTTPException 409: Email ya existe en otro vendedor
         """
         try:
@@ -250,6 +264,18 @@ class VendedorService:
                     raise HTTPException(
                         status_code=HTTPStatus.CONFLICT,
                         detail=f"El email {vendedor_data.email} ya está registrado en otro vendedor."
+                    )
+
+            # Validar que el plan de venta exista si se actualiza
+            if vendedor_data.plan_venta_id is not None:
+                plan_existe = self.db.query(PlanVenta).filter(
+                    PlanVenta.id == vendedor_data.plan_venta_id
+                ).first()
+
+                if not plan_existe:
+                    raise HTTPException(
+                        status_code=HTTPStatus.NOT_FOUND,
+                        detail=f"El plan de venta con ID {vendedor_data.plan_venta_id} no existe."
                     )
 
             # Actualizar solo los campos proporcionados

--- a/src/ventas/services/vendedor_service.py
+++ b/src/ventas/services/vendedor_service.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any, List, Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import func
 from fastapi import Depends, HTTPException
@@ -116,20 +116,22 @@ class VendedorService:
 
     def obtener_vendedor(self, vendedor_id: str) -> Dict[str, Any]:
         """
-        Obtiene un vendedor por su ID.
+        Obtiene un vendedor por su ID con información expandida del plan de venta.
 
         Args:
             vendedor_id: UUID del vendedor
 
         Returns:
-            Dict con los datos del vendedor
+            Dict con los datos del vendedor y su plan de venta
 
         Raises:
             HTTPException 404: Vendedor no encontrado
             HTTPException 500: Error interno
         """
         try:
-            vendedor = self.db.query(Vendedor).filter(
+            vendedor = self.db.query(Vendedor).options(
+                joinedload(Vendedor.plan_venta)
+            ).filter(
                 Vendedor.id == vendedor_id
             ).first()
 
@@ -139,7 +141,7 @@ class VendedorService:
                     detail=f"Vendedor con ID {vendedor_id} no encontrado."
                 )
 
-            return vendedor.to_dict()
+            return vendedor.to_dict(include_plan_venta=True)
 
         except HTTPException:
             raise
@@ -192,23 +194,25 @@ class VendedorService:
         limit: int = 100
     ) -> List[Dict[str, Any]]:
         """
-        Lista todos los vendedores con filtros opcionales.
+        Lista todos los vendedores con información expandida del plan de venta.
 
         Args:
             skip: Número de registros a saltar (paginación)
             limit: Número máximo de registros a retornar
 
         Returns:
-            Lista de vendedores
+            Lista de vendedores con información de sus planes de venta
         """
         try:
-            query = self.db.query(Vendedor)
+            query = self.db.query(Vendedor).options(
+                joinedload(Vendedor.plan_venta)
+            )
 
             query = query.order_by(Vendedor.fecha_creacion.desc())
 
             vendedores = query.offset(skip).limit(limit).all()
 
-            return [vendedor.to_dict() for vendedor in vendedores]
+            return [vendedor.to_dict(include_plan_venta=True) for vendedor in vendedores]
 
         except Exception as e:
             logger.error(f"Error al listar vendedores: {e}")

--- a/src/ventas/tests/test_plan_venta_schema.py
+++ b/src/ventas/tests/test_plan_venta_schema.py
@@ -1,0 +1,228 @@
+import pytest
+from pydantic import ValidationError
+from decimal import Decimal
+from datetime import datetime
+
+from schemas.plan_venta_schema import (
+    CrearPlanVentaSchema,
+    ActualizarPlanVentaSchema,
+)
+from schemas.vendedor_schema import ZonaAsignadaEnum
+
+
+class TestCrearPlanVentaSchema:
+    """Tests para el schema de creación de plan de venta"""
+
+    def test_crear_plan_venta_schema_valido(self):
+        """Test: Crear plan de venta con todos los datos válidos"""
+        data = {
+            "nombre": "Plan Q1 2024 - Perú",
+            "fecha_inicio": "2024-01-01T00:00:00",
+            "fecha_fin": "2024-03-31T23:59:59",
+            "descripcion": "Plan de ventas del primer trimestre",
+            "meta_venta": 100000.00,
+            "zona_asignada": "Perú"
+        }
+
+        plan = CrearPlanVentaSchema(**data)
+
+        assert plan.nombre == "Plan Q1 2024 - Perú"
+        assert plan.descripcion == "Plan de ventas del primer trimestre"
+        assert plan.meta_venta == Decimal("100000.00")
+        assert plan.zona_asignada == ZonaAsignadaEnum.PERU
+
+    def test_crear_plan_venta_sin_campos_opcionales(self):
+        """Test: Crear plan de venta sin campos opcionales"""
+        data = {
+            "nombre": "Plan Q2 2024",
+            "fecha_inicio": "2024-04-01T00:00:00",
+            "fecha_fin": "2024-06-30T23:59:59",
+            "meta_venta": 50000.00
+        }
+
+        plan = CrearPlanVentaSchema(**data)
+
+        assert plan.nombre == "Plan Q2 2024"
+        assert plan.descripcion is None
+        assert plan.zona_asignada is None
+        assert plan.meta_venta == Decimal("50000.00")
+
+    def test_crear_plan_venta_nombre_vacio_falla(self):
+        """Test: Fallar si el nombre está vacío"""
+        data = {
+            "nombre": "   ",
+            "fecha_inicio": "2024-01-01T00:00:00",
+            "fecha_fin": "2024-03-31T23:59:59",
+            "meta_venta": 50000.00
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            CrearPlanVentaSchema(**data)
+
+        assert "nombre" in str(exc_info.value)
+
+    def test_crear_plan_venta_fecha_fin_antes_de_inicio_falla(self):
+        """Test: Fallar si fecha_fin es anterior a fecha_inicio"""
+        data = {
+            "nombre": "Plan Inválido",
+            "fecha_inicio": "2024-12-31T00:00:00",
+            "fecha_fin": "2024-01-01T00:00:00",  # Antes de fecha_inicio
+            "meta_venta": 50000.00
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            CrearPlanVentaSchema(**data)
+
+        assert "fecha_fin" in str(exc_info.value)
+
+    def test_crear_plan_venta_fecha_fin_igual_a_inicio_falla(self):
+        """Test: Fallar si fecha_fin es igual a fecha_inicio"""
+        fecha = "2024-01-01T00:00:00"
+        data = {
+            "nombre": "Plan Inválido",
+            "fecha_inicio": fecha,
+            "fecha_fin": fecha,
+            "meta_venta": 50000.00
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            CrearPlanVentaSchema(**data)
+
+        assert "fecha_fin" in str(exc_info.value)
+
+    def test_crear_plan_venta_meta_negativa_falla(self):
+        """Test: Fallar si la meta de venta es negativa"""
+        data = {
+            "nombre": "Plan Inválido",
+            "fecha_inicio": "2024-01-01T00:00:00",
+            "fecha_fin": "2024-03-31T23:59:59",
+            "meta_venta": -1000.00
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            CrearPlanVentaSchema(**data)
+
+        assert "meta_venta" in str(exc_info.value)
+
+    def test_crear_plan_venta_meta_cero_falla(self):
+        """Test: Fallar si la meta de venta es cero"""
+        data = {
+            "nombre": "Plan Inválido",
+            "fecha_inicio": "2024-01-01T00:00:00",
+            "fecha_fin": "2024-03-31T23:59:59",
+            "meta_venta": 0
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            CrearPlanVentaSchema(**data)
+
+        assert "meta_venta" in str(exc_info.value)
+
+    def test_crear_plan_venta_zona_invalida_falla(self):
+        """Test: Fallar si la zona no es válida"""
+        data = {
+            "nombre": "Plan Inválido",
+            "fecha_inicio": "2024-01-01T00:00:00",
+            "fecha_fin": "2024-03-31T23:59:59",
+            "meta_venta": 50000.00,
+            "zona_asignada": "Argentina"  # No está en el enum
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            CrearPlanVentaSchema(**data)
+
+        assert "zona_asignada" in str(exc_info.value)
+
+    def test_crear_plan_venta_sin_campos_obligatorios_falla(self):
+        """Test: Fallar si faltan campos obligatorios"""
+        data = {
+            "nombre": "Plan Incompleto"
+            # Faltan: fecha_inicio, fecha_fin, meta_venta
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            CrearPlanVentaSchema(**data)
+
+        errors = str(exc_info.value)
+        assert "fecha_inicio" in errors
+        assert "fecha_fin" in errors
+        assert "meta_venta" in errors
+
+    def test_crear_plan_venta_descripcion_vacia_convierte_a_none(self):
+        """Test: Convertir descripción vacía a None"""
+        data = {
+            "nombre": "Plan 2024",
+            "fecha_inicio": "2024-01-01T00:00:00",
+            "fecha_fin": "2024-03-31T23:59:59",
+            "meta_venta": 50000.00,
+            "descripcion": "   "  # Solo espacios
+        }
+
+        plan = CrearPlanVentaSchema(**data)
+
+        assert plan.descripcion is None
+
+
+class TestActualizarPlanVentaSchema:
+    """Tests para el schema de actualización de plan de venta"""
+
+    def test_actualizar_plan_venta_schema_valido(self):
+        """Test: Actualizar plan de venta con datos válidos"""
+        data = {
+            "nombre": "Plan Q1 2024 - Actualizado",
+            "meta_venta": 150000.00,
+            "descripcion": "Meta incrementada"
+        }
+
+        plan = ActualizarPlanVentaSchema(**data)
+
+        assert plan.nombre == "Plan Q1 2024 - Actualizado"
+        assert plan.meta_venta == Decimal("150000.00")
+        assert plan.descripcion == "Meta incrementada"
+
+    def test_actualizar_plan_venta_todos_campos_opcionales(self):
+        """Test: Todos los campos son opcionales en actualización"""
+        data = {}
+
+        plan = ActualizarPlanVentaSchema(**data)
+
+        assert plan.nombre is None
+        assert plan.fecha_inicio is None
+        assert plan.fecha_fin is None
+        assert plan.descripcion is None
+        assert plan.meta_venta is None
+        assert plan.zona_asignada is None
+
+    def test_actualizar_plan_venta_nombre_vacio_falla(self):
+        """Test: Fallar si el nombre está vacío"""
+        data = {
+            "nombre": "   "
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            ActualizarPlanVentaSchema(**data)
+
+        assert "nombre" in str(exc_info.value)
+
+    def test_actualizar_plan_venta_meta_negativa_falla(self):
+        """Test: Fallar si la meta de venta es negativa"""
+        data = {
+            "meta_venta": -5000.00
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            ActualizarPlanVentaSchema(**data)
+
+        assert "meta_venta" in str(exc_info.value)
+
+    def test_actualizar_plan_venta_solo_un_campo(self):
+        """Test: Actualizar solo un campo"""
+        data = {
+            "meta_venta": 200000.00
+        }
+
+        plan = ActualizarPlanVentaSchema(**data)
+
+        assert plan.meta_venta == Decimal("200000.00")
+        assert plan.nombre is None
+        assert plan.fecha_inicio is None

--- a/src/ventas/tests/test_plan_venta_service.py
+++ b/src/ventas/tests/test_plan_venta_service.py
@@ -1,0 +1,409 @@
+import pytest
+from unittest.mock import Mock, MagicMock
+from fastapi import HTTPException
+from decimal import Decimal
+from datetime import datetime
+
+from services.plan_venta_service import PlanVentaService
+from schemas.plan_venta_schema import CrearPlanVentaSchema, ActualizarPlanVentaSchema
+from schemas.vendedor_schema import ZonaAsignadaEnum
+from db.plan_venta_model import PlanVenta
+
+
+class TestPlanVentaServiceCrear:
+    """Tests para crear plan de venta"""
+
+    def test_crear_plan_venta_exitoso(self):
+        """Test: Crear plan de venta exitosamente"""
+        # Arrange
+        mock_db = Mock()
+        mock_db.query().filter().first.return_value = None  # No existe plan con ese nombre
+        mock_db.add = Mock()
+        mock_db.commit = Mock()
+        mock_db.refresh = Mock()
+
+        plan_data = CrearPlanVentaSchema(
+            nombre="Plan Q1 2024 - Perú",
+            fecha_inicio=datetime(2024, 1, 1),
+            fecha_fin=datetime(2024, 3, 31),
+            descripcion="Plan trimestral",
+            meta_venta=Decimal("100000.00"),
+            zona_asignada=ZonaAsignadaEnum.PERU
+        )
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.crear_plan_venta(plan_data)
+
+        # Assert
+        assert mock_db.add.called
+        assert mock_db.commit.called
+        assert "nombre" in result
+        assert result["nombre"] == "Plan Q1 2024 - Perú"
+
+    def test_crear_plan_venta_sin_campos_opcionales(self):
+        """Test: Crear plan de venta sin campos opcionales"""
+        # Arrange
+        mock_db = Mock()
+        mock_db.query().filter().first.return_value = None  # No existe plan con ese nombre
+        mock_db.add = Mock()
+        mock_db.commit = Mock()
+        mock_db.refresh = Mock()
+
+        plan_data = CrearPlanVentaSchema(
+            nombre="Plan Q2 2024",
+            fecha_inicio=datetime(2024, 4, 1),
+            fecha_fin=datetime(2024, 6, 30),
+            meta_venta=Decimal("50000.00")
+        )
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.crear_plan_venta(plan_data)
+
+        # Assert
+        assert mock_db.add.called
+        assert mock_db.commit.called
+
+    def test_crear_plan_venta_nombre_duplicado_falla(self):
+        """Test: Fallar al crear plan de venta con nombre duplicado"""
+        # Arrange
+        mock_db = Mock()
+
+        # Simular que ya existe un plan con ese nombre
+        plan_existente = Mock()
+        plan_existente.nombre = "Plan Q1 2024"
+        mock_db.query().filter().first.return_value = plan_existente
+
+        plan_data = CrearPlanVentaSchema(
+            nombre="Plan Q1 2024",
+            fecha_inicio=datetime(2024, 1, 1),
+            fecha_fin=datetime(2024, 3, 31),
+            meta_venta=Decimal("100000.00")
+        )
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            service.crear_plan_venta(plan_data)
+
+        assert exc_info.value.status_code == 409
+        assert "nombre" in str(exc_info.value.detail).lower()
+
+
+class TestPlanVentaServiceObtener:
+    """Tests para obtener plan de venta"""
+
+    def test_obtener_plan_venta_existente(self):
+        """Test: Obtener plan de venta que existe"""
+        # Arrange
+        mock_db = Mock()
+
+        plan_mock = Mock()
+        plan_mock.to_dict.return_value = {
+            "id": "123",
+            "nombre": "Plan Q1 2024",
+            "meta_venta": "100000.00",
+            "zona_asignada": "Perú"
+        }
+
+        mock_db.query().filter().first.return_value = plan_mock
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.obtener_plan_venta("123")
+
+        # Assert
+        assert result["id"] == "123"
+        assert result["nombre"] == "Plan Q1 2024"
+
+    def test_obtener_plan_venta_no_existente_falla(self):
+        """Test: Fallar al obtener plan de venta que no existe"""
+        # Arrange
+        mock_db = Mock()
+        mock_db.query().filter().first.return_value = None
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            service.obtener_plan_venta("999")
+
+        assert exc_info.value.status_code == 404
+
+
+class TestPlanVentaServiceListar:
+    """Tests para listar planes de venta"""
+
+    def test_listar_planes_venta_exitoso(self):
+        """Test: Listar planes de venta exitosamente"""
+        # Arrange
+        mock_db = Mock()
+
+        plan1 = Mock()
+        plan1.to_dict.return_value = {"id": "1", "nombre": "Plan Q1"}
+
+        plan2 = Mock()
+        plan2.to_dict.return_value = {"id": "2", "nombre": "Plan Q2"}
+
+        mock_query = Mock()
+        mock_query.filter().order_by().offset().limit().all.return_value = [plan1, plan2]
+        mock_query.order_by().offset().limit().all.return_value = [plan1, plan2]
+        mock_db.query.return_value = mock_query
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.listar_planes_venta(skip=0, limit=10)
+
+        # Assert
+        assert len(result) == 2
+        assert result[0]["nombre"] == "Plan Q1"
+        assert result[1]["nombre"] == "Plan Q2"
+
+    def test_listar_planes_venta_con_filtro_zona(self):
+        """Test: Listar planes de venta filtrados por zona"""
+        # Arrange
+        mock_db = Mock()
+
+        plan1 = Mock()
+        plan1.to_dict.return_value = {"id": "1", "nombre": "Plan Perú", "zona_asignada": "Perú"}
+
+        mock_query = Mock()
+        mock_query.filter().order_by().offset().limit().all.return_value = [plan1]
+        mock_db.query.return_value = mock_query
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.listar_planes_venta(skip=0, limit=10, zona_asignada="Perú")
+
+        # Assert
+        assert len(result) == 1
+        assert result[0]["zona_asignada"] == "Perú"
+
+    def test_listar_planes_venta_vacio(self):
+        """Test: Listar planes de venta cuando no hay ninguno"""
+        # Arrange
+        mock_db = Mock()
+
+        mock_query = Mock()
+        mock_query.order_by().offset().limit().all.return_value = []
+        mock_db.query.return_value = mock_query
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.listar_planes_venta(skip=0, limit=10)
+
+        # Assert
+        assert len(result) == 0
+
+
+class TestPlanVentaServiceActualizar:
+    """Tests para actualizar plan de venta"""
+
+    def test_actualizar_plan_venta_exitoso(self):
+        """Test: Actualizar plan de venta exitosamente"""
+        # Arrange
+        mock_db = Mock()
+
+        plan_mock = Mock()
+        plan_mock.id = "123"
+        plan_mock.nombre = "Plan Q1 2024"
+        plan_mock.fecha_inicio = datetime(2024, 1, 1)
+        plan_mock.fecha_fin = datetime(2024, 3, 31)
+        plan_mock.to_dict.return_value = {
+            "id": "123",
+            "nombre": "Plan Q1 2024 - Actualizado",
+            "meta_venta": "150000.00"
+        }
+
+        # Primera llamada: encontrar el plan a actualizar
+        # Segunda llamada: verificar si el nuevo nombre existe (debe retornar None)
+        mock_db.query().filter().first.side_effect = [plan_mock, None]
+        mock_db.commit = Mock()
+        mock_db.refresh = Mock()
+
+        plan_data = ActualizarPlanVentaSchema(
+            nombre="Plan Q1 2024 - Actualizado",
+            meta_venta=Decimal("150000.00")
+        )
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.actualizar_plan_venta("123", plan_data)
+
+        # Assert
+        assert mock_db.commit.called
+        assert result["nombre"] == "Plan Q1 2024 - Actualizado"
+
+    def test_actualizar_plan_venta_no_existente_falla(self):
+        """Test: Fallar al actualizar plan de venta que no existe"""
+        # Arrange
+        mock_db = Mock()
+        mock_db.query().filter().first.return_value = None
+
+        plan_data = ActualizarPlanVentaSchema(nombre="Nuevo Nombre")
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            service.actualizar_plan_venta("999", plan_data)
+
+        assert exc_info.value.status_code == 404
+
+    def test_actualizar_plan_venta_fechas_invalidas_falla(self):
+        """Test: Fallar al actualizar con fecha_fin antes de fecha_inicio"""
+        # Arrange
+        mock_db = Mock()
+
+        plan_mock = Mock()
+        plan_mock.id = "123"
+        plan_mock.fecha_inicio = datetime(2024, 1, 1)
+        plan_mock.fecha_fin = datetime(2024, 3, 31)
+
+        mock_db.query().filter().first.return_value = plan_mock
+
+        # Intentar actualizar fecha_fin a una fecha anterior a fecha_inicio
+        plan_data = ActualizarPlanVentaSchema(
+            fecha_fin=datetime(2023, 12, 31)  # Antes de fecha_inicio
+        )
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            service.actualizar_plan_venta("123", plan_data)
+
+        assert exc_info.value.status_code == 400
+
+    def test_actualizar_plan_venta_nombre_duplicado_falla(self):
+        """Test: Fallar al actualizar con nombre que ya existe en otro plan"""
+        # Arrange
+        mock_db = Mock()
+
+        plan_actual = Mock()
+        plan_actual.id = "123"
+        plan_actual.nombre = "Plan Q1 2024"
+        plan_actual.fecha_inicio = datetime(2024, 1, 1)
+        plan_actual.fecha_fin = datetime(2024, 3, 31)
+
+        otro_plan = Mock()
+        otro_plan.id = "456"
+        otro_plan.nombre = "Plan Q2 2024"
+
+        # Primera llamada: encontrar el plan a actualizar
+        # Segunda llamada: verificar si el nuevo nombre ya existe
+        mock_db.query().filter().first.side_effect = [plan_actual, otro_plan]
+
+        plan_data = ActualizarPlanVentaSchema(
+            nombre="Plan Q2 2024"  # Nombre que ya existe en otro plan
+        )
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            service.actualizar_plan_venta("123", plan_data)
+
+        assert exc_info.value.status_code == 409
+        assert "nombre" in str(exc_info.value.detail).lower()
+
+
+class TestPlanVentaServiceEliminar:
+    """Tests para eliminar plan de venta"""
+
+    def test_eliminar_plan_venta_exitoso(self):
+        """Test: Eliminar plan de venta exitosamente"""
+        # Arrange
+        mock_db = Mock()
+
+        plan_mock = Mock()
+        plan_mock.id = "123"
+
+        mock_db.query().filter().first.return_value = plan_mock
+        mock_db.delete = Mock()
+        mock_db.commit = Mock()
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.eliminar_plan_venta("123")
+
+        # Assert
+        assert mock_db.delete.called
+        assert mock_db.commit.called
+        assert "message" in result
+
+    def test_eliminar_plan_venta_no_existente_falla(self):
+        """Test: Fallar al eliminar plan de venta que no existe"""
+        # Arrange
+        mock_db = Mock()
+        mock_db.query().filter().first.return_value = None
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            service.eliminar_plan_venta("999")
+
+        assert exc_info.value.status_code == 404
+
+
+class TestPlanVentaServiceContar:
+    """Tests para contar planes de venta"""
+
+    def test_contar_planes_venta_exitoso(self):
+        """Test: Contar planes de venta exitosamente"""
+        # Arrange
+        mock_db = Mock()
+        mock_query = Mock()
+        mock_query.count.return_value = 5
+        mock_db.query.return_value = mock_query
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.contar_planes_venta()
+
+        # Assert
+        assert result == 5
+
+    def test_contar_planes_venta_con_filtro_zona(self):
+        """Test: Contar planes de venta filtrados por zona"""
+        # Arrange
+        mock_db = Mock()
+        mock_query = Mock()
+        mock_query.filter().count.return_value = 2
+        mock_db.query.return_value = mock_query
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.contar_planes_venta(zona_asignada="Perú")
+
+        # Assert
+        assert result == 2
+
+    def test_contar_planes_venta_cuando_no_hay_ninguno(self):
+        """Test: Contar planes de venta cuando no hay ninguno"""
+        # Arrange
+        mock_db = Mock()
+        mock_query = Mock()
+        mock_query.count.return_value = 0
+        mock_db.query.return_value = mock_query
+
+        service = PlanVentaService(db=mock_db)
+
+        # Act
+        result = service.contar_planes_venta()
+
+        # Assert
+        assert result == 0

--- a/src/ventas/tests/test_vendedor_schema.py
+++ b/src/ventas/tests/test_vendedor_schema.py
@@ -1,6 +1,6 @@
 import pytest
 from pydantic import ValidationError
-from decimal import Decimal
+from uuid import UUID
 
 from schemas.vendedor_schema import (
     CrearVendedorSchema,
@@ -14,13 +14,13 @@ class TestCrearVendedorSchema:
 
     def test_crear_vendedor_schema_valido(self):
         """Test: Crear vendedor con todos los datos válidos"""
+        plan_id = UUID("550e8400-e29b-41d4-a716-446655440000")
         data = {
             "nombre": "Juan Pérez García",
             "documento_identidad": "12345678",
             "email": "juan.perez@medisupply.com",
             "zona_asignada": "Perú",
-            "plan_venta": "plan-123",
-            "meta_venta": 50000.00
+            "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
         }
 
         vendedor = CrearVendedorSchema(**data)
@@ -29,23 +29,22 @@ class TestCrearVendedorSchema:
         assert vendedor.documento_identidad == "12345678"
         assert vendedor.email == "juan.perez@medisupply.com"
         assert vendedor.zona_asignada == ZonaAsignadaEnum.PERU
-        assert vendedor.plan_venta == "plan-123"
-        assert vendedor.meta_venta == Decimal("50000.00")
+        assert vendedor.plan_venta_id == plan_id
 
-    def test_crear_vendedor_schema_sin_campos_opcionales(self):
-        """Test: Crear vendedor sin campos opcionales"""
+    def test_crear_vendedor_schema_campos_minimos(self):
+        """Test: Crear vendedor solo con campos obligatorios"""
         data = {
             "nombre": "María González",
             "documento_identidad": "87654321",
             "email": "maria@medisupply.com",
-            "zona_asignada": "Colombia"
+            "zona_asignada": "Colombia",
+            "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
         }
 
         vendedor = CrearVendedorSchema(**data)
 
         assert vendedor.nombre == "María González"
-        assert vendedor.plan_venta is None
-        assert vendedor.meta_venta is None
+        assert vendedor.plan_venta_id == UUID("550e8400-e29b-41d4-a716-446655440000")
 
     def test_crear_vendedor_nombre_vacio_falla(self):
         """Test: Fallar si el nombre está vacío"""
@@ -89,26 +88,11 @@ class TestCrearVendedorSchema:
 
         assert "zona_asignada" in str(exc_info.value)
 
-    def test_crear_vendedor_meta_venta_negativa_falla(self):
-        """Test: Fallar si la meta de venta es negativa"""
-        data = {
-            "nombre": "Juan Pérez",
-            "documento_identidad": "12345678",
-            "email": "juan@medisupply.com",
-            "zona_asignada": "Perú",
-            "meta_venta": -1000
-        }
-
-        with pytest.raises(ValidationError) as exc_info:
-            CrearVendedorSchema(**data)
-
-        assert "meta_venta" in str(exc_info.value)
-
     def test_crear_vendedor_sin_campos_obligatorios_falla(self):
         """Test: Fallar si faltan campos obligatorios"""
         data = {
             "nombre": "Juan Pérez"
-            # Faltan: documento_identidad, email, zona_asignada
+            # Faltan: documento_identidad, email, zona_asignada, plan_venta_id
         }
 
         with pytest.raises(ValidationError) as exc_info:
@@ -118,6 +102,7 @@ class TestCrearVendedorSchema:
         assert "documento_identidad" in errors
         assert "email" in errors
         assert "zona_asignada" in errors
+        assert "plan_venta_id" in errors
 
 
 class TestActualizarVendedorSchema:
@@ -128,14 +113,14 @@ class TestActualizarVendedorSchema:
         data = {
             "nombre": "Juan Pérez Actualizado",
             "email": "nuevo@medisupply.com",
-            "meta_venta": 75000.00
+            "plan_venta_id": "550e8400-e29b-41d4-a716-446655440000"
         }
 
         vendedor = ActualizarVendedorSchema(**data)
 
         assert vendedor.nombre == "Juan Pérez Actualizado"
         assert vendedor.email == "nuevo@medisupply.com"
-        assert vendedor.meta_venta == Decimal("75000.00")
+        assert vendedor.plan_venta_id == UUID("550e8400-e29b-41d4-a716-446655440000")
 
     def test_actualizar_vendedor_todos_campos_opcionales(self):
         """Test: Todos los campos son opcionales en actualización"""
@@ -146,8 +131,7 @@ class TestActualizarVendedorSchema:
         assert vendedor.nombre is None
         assert vendedor.email is None
         assert vendedor.zona_asignada is None
-        assert vendedor.plan_venta is None
-        assert vendedor.meta_venta is None
+        assert vendedor.plan_venta_id is None
 
     def test_actualizar_vendedor_nombre_vacio_falla(self):
         """Test: Fallar si el nombre está vacío"""

--- a/src/ventas/tests/test_vendedor_service.py
+++ b/src/ventas/tests/test_vendedor_service.py
@@ -116,7 +116,7 @@ class TestVendedorServiceObtener:
             "zona_asignada": "Perú"
         }
 
-        mock_db.query().filter().first.return_value = vendedor_mock
+        mock_db.query().options().filter().first.return_value = vendedor_mock
 
         service = VendedorService(db=mock_db)
 
@@ -131,7 +131,7 @@ class TestVendedorServiceObtener:
         """Test: Fallar al obtener vendedor que no existe"""
         # Arrange
         mock_db = Mock()
-        mock_db.query().filter().first.return_value = None
+        mock_db.query().options().filter().first.return_value = None
 
         service = VendedorService(db=mock_db)
 
@@ -157,7 +157,7 @@ class TestVendedorServiceListar:
         vendedor2.to_dict.return_value = {"id": "2", "nombre": "María"}
 
         mock_query = Mock()
-        mock_query.order_by().offset().limit().all.return_value = [vendedor1, vendedor2]
+        mock_query.options().order_by().offset().limit().all.return_value = [vendedor1, vendedor2]
         mock_db.query.return_value = mock_query
 
         service = VendedorService(db=mock_db)
@@ -176,7 +176,7 @@ class TestVendedorServiceListar:
         mock_db = Mock()
 
         mock_query = Mock()
-        mock_query.order_by().offset().limit().all.return_value = []
+        mock_query.options().order_by().offset().limit().all.return_value = []
         mock_db.query.return_value = mock_query
 
         service = VendedorService(db=mock_db)

--- a/src/ventas/tests/test_vendedor_service.py
+++ b/src/ventas/tests/test_vendedor_service.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import Mock, MagicMock
 from fastapi import HTTPException
-from decimal import Decimal
+from uuid import UUID
 
 from services.vendedor_service import VendedorService
 from schemas.vendedor_schema import CrearVendedorSchema, ActualizarVendedorSchema, ZonaAsignadaEnum
@@ -15,7 +15,14 @@ class TestVendedorServiceCrear:
         """Test: Crear vendedor exitosamente"""
         # Arrange
         mock_db = Mock()
-        mock_db.query().filter().first.return_value = None  # No existe vendedor con ese email
+
+        # Mock del plan que existe
+        plan_mock = Mock()
+        plan_mock.id = UUID("550e8400-e29b-41d4-a716-446655440000")
+
+        # Primera llamada: verificar email (None = no existe)
+        # Segunda llamada: verificar plan (retorna el plan mock)
+        mock_db.query().filter().first.side_effect = [None, plan_mock]
         mock_db.add = Mock()
         mock_db.commit = Mock()
         mock_db.refresh = Mock()
@@ -25,8 +32,7 @@ class TestVendedorServiceCrear:
             documento_identidad="12345678",
             email="juan@medisupply.com",
             zona_asignada=ZonaAsignadaEnum.PERU,
-            plan_venta="plan-123",
-            meta_venta=Decimal("50000.00")
+            plan_venta_id=UUID("550e8400-e29b-41d4-a716-446655440000")
         )
 
         service = VendedorService(db=mock_db)
@@ -39,6 +45,32 @@ class TestVendedorServiceCrear:
         assert mock_db.commit.called
         assert "nombre" in result
         assert result["nombre"] == "Juan Pérez"
+
+    def test_crear_vendedor_plan_no_existe_falla(self):
+        """Test: Fallar al crear vendedor con plan que no existe"""
+        # Arrange
+        mock_db = Mock()
+
+        # Primera llamada: verificar email (None = no existe)
+        # Segunda llamada: verificar plan (None = plan no existe)
+        mock_db.query().filter().first.side_effect = [None, None]
+
+        vendedor_data = CrearVendedorSchema(
+            nombre="Juan Pérez",
+            documento_identidad="12345678",
+            email="juan@medisupply.com",
+            zona_asignada=ZonaAsignadaEnum.PERU,
+            plan_venta_id=UUID("550e8400-e29b-41d4-a716-446655440000")
+        )
+
+        service = VendedorService(db=mock_db)
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            service.crear_vendedor(vendedor_data)
+
+        assert exc_info.value.status_code == 404
+        assert "plan" in str(exc_info.value.detail).lower()
 
     def test_crear_vendedor_email_duplicado_falla(self):
         """Test: Fallar al crear vendedor con email duplicado"""
@@ -54,7 +86,8 @@ class TestVendedorServiceCrear:
             nombre="Juan Pérez",
             documento_identidad="12345678",
             email="juan@medisupply.com",
-            zona_asignada=ZonaAsignadaEnum.PERU
+            zona_asignada=ZonaAsignadaEnum.PERU,
+            plan_venta_id=UUID("550e8400-e29b-41d4-a716-446655440000")
         )
 
         service = VendedorService(db=mock_db)


### PR DESCRIPTION
This pull request introduces a new API for managing sales plans (`planes de venta`) and refactors the vendor (`vendedor`) schemas and endpoints to enforce the association between vendors and sales plans via a required `plan_venta_id` field. It also integrates the new sales plans router into the main application and updates documentation and validation logic for both schemas.

**Sales Plans API and Integration**

* Added a new router `planes_venta_router` in `router/planes_venta.py` with endpoints to create, list, retrieve, update, and delete sales plans, including request/response validation and documentation.
* Integrated `planes_venta_router` into the main `ventas_router` in `router/ventas.py`, making sales plans API available under `/planes`. [[1]](diffhunk://#diff-746e42879b65eb27551bfcefa5749c86e93ae1d81d1bfc23502997235e7f45f5R6) [[2]](diffhunk://#diff-746e42879b65eb27551bfcefa5749c86e93ae1d81d1bfc23502997235e7f45f5L18-R21)

**Vendor Schema and Endpoint Refactor**

* Updated `vendedor_schema.py` so vendors must be associated with a sales plan via a required `plan_venta_id` (UUID), removing the old optional `plan_venta` and `meta_venta` fields. Also updated example data and validation logic accordingly. [[1]](diffhunk://#diff-b2272d6468164d05320edf99d128a11ba9ff7b8c237c3eadbc122876a3d767dbL4-R4) [[2]](diffhunk://#diff-b2272d6468164d05320edf99d128a11ba9ff7b8c237c3eadbc122876a3d767dbL34-R36) [[3]](diffhunk://#diff-b2272d6468164d05320edf99d128a11ba9ff7b8c237c3eadbc122876a3d767dbL67-R62) [[4]](diffhunk://#diff-b2272d6468164d05320edf99d128a11ba9ff7b8c237c3eadbc122876a3d767dbL88-R84) [[5]](diffhunk://#diff-b2272d6468164d05320edf99d128a11ba9ff7b8c237c3eadbc122876a3d767dbL120-R109)
* Modified vendor endpoints and documentation in `router/vendedores.py` to use the new `plan_venta_id` field, update response examples, and clarify that this association is now mandatory. [[1]](diffhunk://#diff-e8a5274abf839f49defd2b0e5384f47efff80408274f010bc8b27bcb2a2b05f9L19-R19) [[2]](diffhunk://#diff-e8a5274abf839f49defd2b0e5384f47efff80408274f010bc8b27bcb2a2b05f9L35-R36) [[3]](diffhunk://#diff-e8a5274abf839f49defd2b0e5384f47efff80408274f010bc8b27bcb2a2b05f9L56-R64) [[4]](diffhunk://#diff-e8a5274abf839f49defd2b0e5384f47efff80408274f010bc8b27bcb2a2b05f9L80-R80)

**Sales Plan Schema and Validation**

* Added `plan_venta_schema.py` with schemas for creating and updating sales plans, including field validation (e.g., unique name, date logic, monetary constraints) and example data for API docs.

<img width="1328" height="277" alt="Screenshot 2025-10-26 at 12 51 59 PM" src="https://github.com/user-attachments/assets/ff2676ab-c7e6-4853-9c7c-03c94e9ee544" />

