### PR TITLE
Feature/medsup 3 registro visita

### DIFF
--- a/collection/Medisupply.postman_collection2.json
+++ b/collection/Medisupply.postman_collection2.json
@@ -1894,7 +1894,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"detalle\": \"Visita exitosa. Cliente interesado en producto X.\",\n    \"evidencia\": \"https://mi-storage.com/fotos/visita-123.jpg\",\n    \"cliente_contacto\": \"Ana Pérez - Jefe de Compras\",\n    \"inicio\": \"2025-11-01T10:05:00Z\",\n    \"fin\": \"2025-11-01T10:45:00Z\",\n    \"estado\": \"TOMADA\"\n}",
+									"raw": "{\n    \"detalle\": \"Visita exitosa. Cliente interesado en producto X.\",\n    \"evidencia\": \"https://mi-storage.com/fotos/visita-123.jpg\",\n    \"cliente_contacto\": \"Ana Pérez - Jefe de Compras\",\n    \"inicio\": \"2025-11-01T10:05:00Z\",\n    \"fin\": \"2025-11-01T10:45:00Z\",\n    \"estado\": \"REALIZADA\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3095,7 +3095,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"detalle\": \"Visita exitosa. Cliente interesado en producto X.\",\n    \"evidencia\": \"https://mi-storage.com/fotos/visita-123.jpg\",\n    \"cliente_contacto\": \"Ana Pérez - Jefe de Compras\",\n    \"inicio\": \"2025-11-01T10:05:00Z\",\n    \"fin\": \"2025-11-01T10:45:00Z\",\n    \"estado\": \"TOMADA\"\n}",
+							"raw": "{\n    \"detalle\": \"Visita exitosa. Cliente interesado en producto X.\",\n    \"evidencia\": \"https://mi-storage.com/fotos/visita-123.jpg\",\n    \"cliente_contacto\": \"Ana Pérez - Jefe de Compras\",\n    \"inicio\": \"2025-11-01T10:05:00Z\",\n    \"fin\": \"2025-11-01T10:45:00Z\",\n    \"estado\": \"REALIZADA\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -454,6 +454,7 @@ services:
       - GOOGLE_CLOUD_PROJECT_ID=medisupply-474421
       - AUTENTICACION_SERVICE_URL=http://autenticacion-service:3000
       - PRODUCTOS_SERVICE_URL=http://productos-service:3000
+      - ORDENES_QUERIES_SERVICE_URL=http://order-query-api:3000
     volumes:
       - ./src/visitas:/app
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_DB=0
+      - PRODUCTOS_SERVICE_URL=http://productos-service:3000
     volumes:
       - ./src/ordenes/queries/api:/app
     networks:

--- a/src/autenticacion/router/auth_router.py
+++ b/src/autenticacion/router/auth_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Path
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 from db.database import get_db
@@ -122,3 +122,21 @@ def get_sellers(
     Endpoint público para obtener lista de IDs de vendedores activos.
     """
     return auth_service.get_active_seller_ids(db)
+
+
+@router.get(
+    "/user-by-client/{client_id}",
+    response_model=UserResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Obtener usuario por ID de Cliente",
+    description="Busca y devuelve un usuario basado en el UUID del cliente (id_client) al que está asociado."
+)
+def get_user_by_client_id(
+    client_id: str = Path(..., description="ID del cliente (id_client) a buscar"),
+    db: Session = Depends(get_db),
+    auth_service: AuthService = Depends(get_auth_service)
+):
+    """
+    Endpoint (público) para encontrar un usuario por su id_client.
+    """
+    return auth_service.get_user_by_client_id(db, client_id)

--- a/src/autenticacion/services/auth_service.py
+++ b/src/autenticacion/services/auth_service.py
@@ -274,6 +274,27 @@ class AuthService:
         """
         sellers = db.query(User.id).filter(User.role == "seller", User.is_active == True).all()
         return [s.id for s in sellers]
+    
+    def get_user_by_client_id(self, db: Session, client_id: str) -> UserResponse:
+        """
+        Busca un usuario por su 'id_client' asociado.
+        """
+        user = db.query(User).filter(User.id_client == client_id).first()
+
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No se encontró un usuario asociado al id_client {client_id}"
+            )
+        
+        if not user.is_active:
+             raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="El usuario asociado a este cliente está inactivo"
+            )
+
+        user_dict = user.to_dict()
+        return UserResponse(**user_dict)
 
 
 

--- a/src/bff-movil/router/visitas.py
+++ b/src/bff-movil/router/visitas.py
@@ -86,6 +86,8 @@ async def get_rutas_por_fecha_y_vendedor(
 )
 async def get_detalle_visita(
     visita_id: UUID4 = Path(..., description="ID de la visita a consultar"), 
+    lat_actual: Optional[float] = Query(None, description="Latitud actual del vendedor para optimizar ruta"),
+    lon_actual: Optional[float] = Query(None, description="Longitud actual del vendedor para optimizar ruta"),
     service: VisitasService = Depends(get_visitas_service)
 ):
     """
@@ -93,7 +95,7 @@ async def get_detalle_visita(
     """
     try:
         logger.info(f"BFF Móvil: Solicitud de detalle para visita {visita_id}")
-        result = await service.get_visita_detalle(visita_id)
+        result = await service.get_visita_detalle(visita_id, lon_actual=lon_actual, lat_actual=lat_actual)
         logger.info(f"BFF Móvil: Retornando detalle de visita {visita_id}")
         return result
     except HTTPException:

--- a/src/bff-movil/router/visitas.py
+++ b/src/bff-movil/router/visitas.py
@@ -58,6 +58,8 @@ async def crear_nueva_ruta_visita(
 async def get_rutas_por_fecha_y_vendedor( 
     fecha: date = Query(..., description="Fecha a consultar en formato YYYY-MM-DD"),
     vendedor_id: UUID4 = Query(..., description="ID del vendedor a consultar"), 
+    lat_actual: Optional[float] = Query(None, description="Latitud actual del vendedor para optimizar ruta"),
+    lon_actual: Optional[float] = Query(None, description="Longitud actual del vendedor para optimizar ruta"),
     service: VisitasService = Depends(get_visitas_service)
 ):
     """
@@ -65,7 +67,7 @@ async def get_rutas_por_fecha_y_vendedor(
     """
     try:
         logger.info(f"BFF Móvil: Solicitud de rutas para vendedor {vendedor_id} en fecha {fecha}")
-        result = await service.get_rutas_del_dia(fecha, vendedor_id)
+        result = await service.get_rutas_del_dia(fecha, vendedor_id, lat_actual, lon_actual)
         logger.info(f"BFF Móvil: Retornando {len(result)} rutas")
         return result
     except HTTPException:

--- a/src/bff-movil/schemas/visitas_schema.py
+++ b/src/bff-movil/schemas/visitas_schema.py
@@ -11,7 +11,7 @@ from enum import Enum
 class EstadoVisitaEnum(str, Enum):
     """Define los estados permitidos para una visita."""
     PENDIENTE = "PENDIENTE"
-    TOMADA = "TOMADA"
+    REALIZADA = "REALIZADA"
     CANCELADA = "CANCELADA"
 
 class CrearRutaVisitaSchema(BaseModel):
@@ -50,7 +50,7 @@ class RutaVisitaItemSchema(BaseModel):
     nombre: str = Field(..., description="Nombre del cliente institucional")
     direccion: Optional[str] = Field(None, description="Dirección del cliente")
     hora_de_la_cita: str = Field(..., description="Hora de la visita en formato HH:MM (ej: '08:50')")
-    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, TOMADA, CANCELADA)")
+    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, REALIZADA, CANCELADA)")
 
     class Config:
         from_attributes = True
@@ -73,7 +73,7 @@ class ActualizarVisitaSchema(BaseModel):
     cliente_contacto: Optional[str] = Field(None, max_length=100, description="Nombre del contacto en el cliente")
     detalle: Optional[str] = Field(None, max_length=100, description="Detalles o notas de la visita")
     evidencia: Optional[str] = Field(None, max_length=100, description="URL de la foto o video de evidencia")
-    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, TOMADA, CANCELADA)")
+    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, REALIZADA, CANCELADA)")
 
     class Config:
         from_attributes = True

--- a/src/bff-movil/schemas/visitas_schema.py
+++ b/src/bff-movil/schemas/visitas_schema.py
@@ -25,6 +25,11 @@ class CrearRutaVisitaSchema(BaseModel):
     class Config:
         from_attributes = True
 
+class ProductoPreferidoSchema(BaseModel):
+    id_producto: str
+    nombre: str
+    cantidad_total: int
+
 
 class VisitaResponseSchema(BaseModel):
     """Esquema de respuesta para una visita creada o consultada."""
@@ -43,7 +48,7 @@ class VisitaResponseSchema(BaseModel):
 
     class Config:
         from_attributes = True
-
+ 
 class RutaVisitaItemSchema(BaseModel):
     """
     Schema simplificado para la lista de rutas de visita, 
@@ -70,6 +75,10 @@ class VisitaDetalleResponseSchema(VisitaResponseSchema):
     notas_visitas_anteriores: List[NotaVisitaAnteriorSchema] = Field(
         default_factory=list, 
         description="Lista de notas de visitas pasadas del mismo cliente."
+    )
+    productos_preferidos: List[ProductoPreferidoSchema] = Field(
+        default_factory=list,
+        description="Ranking de productos más pedidos por este cliente."
     )
 
     class Config:

--- a/src/bff-movil/schemas/visitas_schema.py
+++ b/src/bff-movil/schemas/visitas_schema.py
@@ -21,6 +21,10 @@ class NotaVisitaAnteriorSchema(BaseModel):
 class CrearRutaVisitaSchema(BaseModel):
     """Esquema de datos requeridos para crear una nueva ruta de visita."""
     cliente_id: UUID4 = Field(..., description="UUID del cliente a visitar.")
+    fecha_visita_programada: Optional[date] = Field(
+        None, 
+        description="Fecha opcional para la visita (YYYY-MM-DD). Si es None, se usa la lógica de hoy/próximo día hábil."
+    )
 
     class Config:
         from_attributes = True

--- a/src/bff-movil/schemas/visitas_schema.py
+++ b/src/bff-movil/schemas/visitas_schema.py
@@ -1,18 +1,22 @@
-# src/bff-movil/schemas/visita_schema.py
-
 from datetime import datetime, date
-from typing import Optional, Dict, List
+from typing import Optional, Dict
 from pydantic import BaseModel, UUID4, Field
+from typing import List
 import uuid
 from enum import Enum
-
-# --- Copia exacta de los schemas del microservicio ---
 
 class EstadoVisitaEnum(str, Enum):
     """Define los estados permitidos para una visita."""
     PENDIENTE = "PENDIENTE"
     REALIZADA = "REALIZADA"
     CANCELADA = "CANCELADA"
+
+class NotaVisitaAnteriorSchema(BaseModel):
+    fecha_visita_programada: datetime
+    detalle: Optional[str] = None
+
+    class Config:
+        from_attributes = True
 
 class CrearRutaVisitaSchema(BaseModel):
     """Esquema de datos requeridos para crear una nueva ruta de visita."""
@@ -50,7 +54,7 @@ class RutaVisitaItemSchema(BaseModel):
     nombre: str = Field(..., description="Nombre del cliente institucional")
     direccion: Optional[str] = Field(None, description="Dirección del cliente")
     hora_de_la_cita: str = Field(..., description="Hora de la visita en formato HH:MM (ej: '08:50')")
-    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, REALIZADA, CANCELADA)")
+    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, RELIZADA, CANCELADA)")
 
     class Config:
         from_attributes = True
@@ -59,9 +63,14 @@ class VisitaDetalleResponseSchema(VisitaResponseSchema):
     """
     Schema de respuesta con toda la información de una visita,
     enriquecida con detalles del cliente.
+    Hereda todos los campos de VisitaBaseResponseSchema.
     """
     nombre_institucion: str = Field(..., description="Nombre del cliente institucional")
     direccion: Optional[str] = Field(None, description="Dirección del cliente")
+    notas_visitas_anteriores: List[NotaVisitaAnteriorSchema] = Field(
+        default_factory=list, 
+        description="Lista de notas de visitas pasadas del mismo cliente."
+    )
 
     class Config:
         from_attributes = True

--- a/src/bff-movil/schemas/visitas_schema.py
+++ b/src/bff-movil/schemas/visitas_schema.py
@@ -72,6 +72,7 @@ class VisitaDetalleResponseSchema(VisitaResponseSchema):
     """
     nombre_institucion: str = Field(..., description="Nombre del cliente institucional")
     direccion: Optional[str] = Field(None, description="Dirección del cliente")
+    cliente_contacto: Optional[str] = Field(None, description="Nombre del contacto en el cliente")
     notas_visitas_anteriores: List[NotaVisitaAnteriorSchema] = Field(
         default_factory=list, 
         description="Lista de notas de visitas pasadas del mismo cliente."
@@ -79,6 +80,10 @@ class VisitaDetalleResponseSchema(VisitaResponseSchema):
     productos_preferidos: List[ProductoPreferidoSchema] = Field(
         default_factory=list,
         description="Ranking de productos más pedidos por este cliente."
+    )
+    tiempo_desplazamiento: Optional[str] = Field(
+        None, 
+        description="Tiempo de viaje estimado desde la ubicación actual del vendedor (ej: '15 min')."
     )
 
     class Config:

--- a/src/bff-movil/services/visitas_service.py
+++ b/src/bff-movil/services/visitas_service.py
@@ -59,12 +59,14 @@ class VisitasService:
             raise HTTPException(status_code=500, detail="Error interno del servidor")
 
 
-    async def get_rutas_del_dia(self, fecha: date, vendedor_id: UUID4) -> List[Dict[str, Any]]:
+    async def get_rutas_del_dia(self, fecha: date, vendedor_id: UUID4, lat_actual, lon_actual) -> List[Dict[str, Any]]:
         """Llama al GET /api/visitas/rutas-del-dia del microservicio."""
         try:
             params = {
                 "fecha": str(fecha),
-                "vendedor_id": str(vendedor_id)
+                "vendedor_id": str(vendedor_id),
+                "lat_actual": lat_actual,
+                "lon_actual": lon_actual
             }
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(

--- a/src/bff-movil/services/visitas_service.py
+++ b/src/bff-movil/services/visitas_service.py
@@ -44,7 +44,7 @@ class VisitasService:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.post(
                     f"{self.base_url}/api/visitas/",
-                    json=data.model_dump(mode='json') # Pydantic v2
+                    json=data.model_dump(mode='json')
                 )
                 response.raise_for_status()
                 return response.json()

--- a/src/bff-movil/services/visitas_service.py
+++ b/src/bff-movil/services/visitas_service.py
@@ -86,12 +86,17 @@ class VisitasService:
             raise HTTPException(status_code=500, detail="Error interno del servidor")
 
 
-    async def get_visita_detalle(self, visita_id: UUID4) -> Dict[str, Any]:
+    async def get_visita_detalle(self, visita_id: UUID4, lat_actual, lon_actual) -> Dict[str, Any]:
         """Llama al GET /api/visitas/{visita_id} del microservicio."""
         try:
+            params = {
+                "lat_actual": lat_actual,
+                "lon_actual": lon_actual
+            }
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(
-                    f"{self.base_url}/api/visitas/{visita_id}"
+                    f"{self.base_url}/api/visitas/{visita_id}",
+                    params=params
                 )
                 response.raise_for_status()
                 return response.json()

--- a/src/ordenes/queries/api/db/order_model.py
+++ b/src/ordenes/queries/api/db/order_model.py
@@ -1,0 +1,100 @@
+from sqlalchemy import Column, DateTime, Integer, String, Numeric, ForeignKey
+from sqlalchemy.orm import relationship
+from datetime import datetime, timezone
+import uuid
+from decimal import Decimal
+
+from .database import Base
+from sqlalchemy.dialects.postgresql import UUID
+
+
+class DetalleOrden(Base):
+    __tablename__ = "detalles_ordenes"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    fecha_creacion = Column(DateTime, default=datetime.now())
+    fecha_actualizacion = Column(DateTime, default=datetime.now())
+    id_orden = Column(UUID(as_uuid=True), ForeignKey("ordenes.id"), nullable=False)
+    id_producto = Column(UUID(as_uuid=True), nullable=False)
+    cantidad = Column(Integer, nullable=False)
+    precio_unitario = Column(Numeric, nullable=False)
+    subtotal = Column(Numeric, nullable=False)
+    observaciones = Column(String, nullable=True)
+    orden = relationship("Orden", back_populates="detalles")
+
+    def __init__(self, id_orden, id_producto, cantidad, precio_unitario, observaciones):
+        now = datetime.now(timezone.utc)
+        self.fecha_creacion = now
+        self.fecha_actualizacion = now
+        self.id_orden = id_orden
+        self.id_producto = id_producto
+        self.cantidad = cantidad
+        self.precio_unitario = precio_unitario
+        self.subtotal = precio_unitario * cantidad
+        self.observaciones = observaciones
+
+    def to_dict(self):
+        """Convert DetalleOrden instance to dictionary"""
+        return {
+            "id": str(self.id),
+            "fecha_creacion": self.fecha_creacion,
+            "fecha_actualizacion": self.fecha_actualizacion,
+            "id_orden": str(self.id_orden),
+            "id_producto": str(self.id_producto),
+            "cantidad": self.cantidad,
+            "precio_unitario": float(self.precio_unitario) if isinstance(self.precio_unitario, Decimal) else self.precio_unitario,
+            "subtotal": float(self.subtotal) if isinstance(self.subtotal, Decimal) else self.subtotal,
+            "observaciones": self.observaciones,
+        }
+
+
+class Orden(Base):
+    __tablename__ = "ordenes"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    fecha_creacion = Column(DateTime, default=datetime.now())
+    fecha_actualizacion = Column(DateTime, default=datetime.now())
+    numero_orden = Column(String, nullable=False, unique=True)
+    estado = Column(String, nullable=False)
+    valor_total = Column(Numeric, nullable=False)
+    id_cliente = Column(UUID(as_uuid=True), nullable=False)
+    id_vendedor = Column(UUID(as_uuid=True), nullable=False)
+    creado_por = Column(UUID(as_uuid=True), nullable=False)
+    fecha_entrega_estimada = Column(DateTime, nullable=False)
+    observaciones = Column(String, nullable=True)
+    detalles = relationship("DetalleOrden", back_populates="orden")
+
+    def __init__(self, id, numero_orden, estado, id_cliente, id_vendedor, creado_por, fecha_entrega_estimada, observaciones):
+        now = datetime.now(timezone.utc)
+        self.id = id if id else uuid.uuid4()
+        self.fecha_creacion = now
+        self.fecha_actualizacion = now
+        self.numero_orden = numero_orden if numero_orden else self.generar_numero_orden()
+        self.estado = estado
+        self.valor_total = 0
+        self.id_cliente = id_cliente
+        self.id_vendedor = id_vendedor
+        self.creado_por = creado_por
+        self.fecha_entrega_estimada = fecha_entrega_estimada
+        self.observaciones = observaciones
+    
+    def generar_numero_orden(self):
+        date_part = datetime.now().strftime('%y%m%d')
+        uuid_part = str(uuid.uuid4())[:8].upper()
+        return f"ORD-{date_part}-{uuid_part}"
+
+    def to_dict(self):
+        """Convert Orden instance to dictionary"""
+        return {
+            "id": str(self.id),
+            "fecha_creacion": self.fecha_creacion,
+            "fecha_actualizacion": self.fecha_actualizacion,
+            "numero_orden": self.numero_orden,
+            "estado": self.estado,
+            "valor_total": float(self.valor_total) if isinstance(self.valor_total, Decimal) else self.valor_total,
+            "id_cliente": str(self.id_cliente),
+            "id_vendedor": str(self.id_vendedor),
+            "creado_por": str(self.creado_por),
+            "fecha_entrega_estimada": self.fecha_entrega_estimada,
+            "observaciones": self.observaciones,
+        }

--- a/src/ordenes/queries/api/router/order_router.py
+++ b/src/ordenes/queries/api/router/order_router.py
@@ -12,6 +12,7 @@ from schemas.order_schema import (
     IdsResponse,
     CacheHealthResponse,
     CacheInvalidationResponse,
+    TopProductsResponse,
 )
 import jwt
 
@@ -150,6 +151,21 @@ async def get_orders_by_client(
         "total_pages": (total + page_size - 1) // page_size if total > 0 else 0,
     }
 
+@order_router.get("/client-top-products", response_model=TopProductsResponse)
+async def get_client_top_products(
+    client_id: str = Query(..., description="ID del cliente a consultar"),
+    limit: int = Query(5, ge=1, le=50, description="Cantidad de productos a mostrar (Top N)"),
+    order_service: OrderService = Depends(get_order_service),
+):
+    """
+    Obtiene el ranking de productos más solicitados (Top N) por un cliente específico para recomendarlos
+    """
+    data = await order_service.get_top_products_by_client(
+        id_cliente=client_id,
+        limit=limit
+    )
+    
+    return {"data": data}
 
 @order_router.get("/{order_id}", response_model=SingleOrderResponse)
 async def get_order(order_id: str, order_service: OrderService = Depends(get_order_service)):

--- a/src/ordenes/queries/api/schemas/order_schema.py
+++ b/src/ordenes/queries/api/schemas/order_schema.py
@@ -84,4 +84,10 @@ class CacheInvalidationResponse(BaseModel):
     client_id: Optional[str] = None
     reason: Optional[str] = None
 
+class TopProductSchema(BaseModel):
+    id_producto: str
+    nombre: str
+    cantidad_total: int
 
+class TopProductsResponse(BaseModel):
+    data: List[TopProductSchema]

--- a/src/ordenes/queries/api/services/order_service.py
+++ b/src/ordenes/queries/api/services/order_service.py
@@ -10,7 +10,16 @@ from http import HTTPStatus
 from services.cache_service import CacheService
 from datetime import datetime
 import logging
-
+import httpx  
+import os     
+from sqlalchemy import func, desc
+logger = logging.getLogger(__name__)
+try:
+    from db.order_model import Orden, DetalleOrden
+except ImportError:
+    logger.error("Error importando Orden y DetalleOrden. Asegúrate de copiar 'order_model.py' a la carpeta 'db' de 'queries'.")
+    class Orden: pass
+    class DetalleOrden: pass
 logger = logging.getLogger(__name__)
 
 
@@ -18,6 +27,34 @@ class OrderService:
     def __init__(self, db: Session = Depends(get_db)):
         self.db = db
         self.cache_service = CacheService()
+        self.productos_service_url = os.getenv(
+            "PRODUCTOS_SERVICE_URL", "http://productos-service:3000" 
+        )
+
+    async def _get_products_batch_data(self, product_ids: List[str]) -> List[Dict[str, Any]]:
+        """
+        Llama al servicio de Productos (usando /by-ids) para obtener los
+        nombres y detalles de una lista de IDs.
+        """
+        if not product_ids:
+            return []
+        
+        request_body = {"ids": product_ids}
+        endpoint_url = f"{self.productos_service_url}/api/productos/by-ids" 
+        
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.post(endpoint_url, json=request_body)
+            
+            if response.status_code == HTTPStatus.OK:
+                return response.json()
+            else:
+                logger.error(f"Error del servicio de productos ({endpoint_url}): {response.status_code} - {response.text}")
+                return []
+        
+        except httpx.RequestError as e:
+            logger.error(f"Error de conexión al servicio de productos ({endpoint_url}): {e}")
+            return []
 
     def _enrich_order_with_names(self, order_data: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -275,6 +312,58 @@ class OrderService:
             raise HTTPException(
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 detail="Error interno al contar órdenes del cliente."
+            )
+        
+    async def get_top_products_by_client(
+        self,
+        id_cliente: str,
+        limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """
+        Calcula los productos más solicitados por un cliente usando agregación SQL
+        directamente en las tablas 'ordenes' y 'detalles_ordenes'.
+        """
+        try:
+            top_products_query = (
+                self.db.query(
+                    DetalleOrden.id_producto,
+                    func.sum(DetalleOrden.cantidad).label("cantidad_total")
+                )
+                .join(Orden, Orden.id == DetalleOrden.id_orden)
+                .filter(Orden.id_cliente == id_cliente)
+                .group_by(DetalleOrden.id_producto)
+                .order_by(desc("cantidad_total")) 
+                .limit(limit)
+            )
+            
+            top_products_db = top_products_query.all()
+
+            if not top_products_db:
+                return []
+
+            product_ids = [str(p.id_producto) for p in top_products_db]
+            
+            products_data_list = await self._get_products_batch_data(product_ids)
+            products_map = {p.get("id"): p for p in products_data_list}
+
+            result = []
+            for product_stat in top_products_db:
+                pid = str(product_stat.id_producto)
+                product_info = products_map.get(pid, {})
+                
+                result.append({
+                    "id_producto": pid,
+                    "nombre": product_info.get("nombre", "Nombre no encontrado"),
+                    "cantidad_total": int(product_stat.cantidad_total)
+                })
+
+            return result
+
+        except Exception as e:
+            logger.error(f"Error calculando top products para cliente {id_cliente}: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al calcular productos más solicitados."
             )
 
 

--- a/src/visitas/router/visita_router.py
+++ b/src/visitas/router/visita_router.py
@@ -32,6 +32,7 @@ visita_router = APIRouter()
     Crea un registro de visita programada.
     Solo requiere el `cliente_id`.
     El `vendedor_id` se obtiene automáticamente del microservicio de Clientes.
+    La fecha se asigna a las 00:00 UTC del día hábil.
     """ 
 )
 async def crear_nueva_ruta_visita(
@@ -59,23 +60,32 @@ async def crear_nueva_ruta_visita(
 @visita_router.get(
     "/rutas-del-dia",
     response_model=List[RutaVisitaItemSchema],
-    summary="Obtener las rutas de visita para una fecha y vendedor", 
+    summary="Obtener la ruta de visitas optimizada del día", 
     description="""
-    Obtiene todas las visitas programadas para una FECHA específica (YYYY-MM-DD)
-    y un VENDEDOR específico (UUID), ordenadas por hora. 
-    La respuesta incluye detalles del cliente (nombre, dirección).
+    Obtiene todas las visitas PENDIENTES para una fecha y vendedor.
+    Si se proveen 'lat_actual' y 'lon_actual', la lista vendrá
+    optimizada por ruta (Google Maps) y el campo 'hora_de_la_cita'
+    contendrá el tiempo de viaje (ej: "15 min").
+    Si no se proveen, listará las visitas pendientes del día (sin optimizar).
     """ 
 )
 async def get_rutas_por_fecha_y_vendedor( 
     fecha: date = Query(..., description="Fecha a consultar en formato YYYY-MM-DD"),
-    vendedor_id: UUID4 = Query(..., description="ID del vendedor a consultar"), 
+    vendedor_id: UUID4 = Query(..., description="ID del vendedor a consultar"),
+    lat_actual: Optional[float] = Query(None, description="Latitud actual del vendedor para optimizar ruta"),
+    lon_actual: Optional[float] = Query(None, description="Longitud actual del vendedor para optimizar ruta"),
     service: VisitaService = Depends(get_visita_service)
 ):
     """
-    Obtiene la lista de rutas de visita para una fecha y vendedor dados.
+    Obtiene la lista de rutas de visita, optimizada si se provee ubicación.
     """
     try:
-        rutas = await service.get_rutas_por_fecha_y_vendedor(fecha, vendedor_id)
+        rutas = await service.get_rutas_por_fecha_y_vendedor(
+            fecha=fecha, 
+            vendedor_id=vendedor_id,
+            lat_actual=lat_actual,
+            lon_actual=lon_actual 
+        )
         return rutas
     except HTTPException as he:
         raise he
@@ -93,7 +103,7 @@ async def get_rutas_por_fecha_y_vendedor(
     description="""
     Obtiene toda la información almacenada de una visita,
     dado su ID. Además, enriquece la respuesta con
-    el nombre, la dirección y el contacto del cliente.
+    el nombre, dirección, notas anteriores y productos preferidos.
     """
 )
 async def get_detalle_visita(

--- a/src/visitas/router/visita_router.py
+++ b/src/visitas/router/visita_router.py
@@ -108,13 +108,15 @@ async def get_rutas_por_fecha_y_vendedor(
 )
 async def get_detalle_visita(
     visita_id: UUID4 = Path(..., description="ID de la visita a consultar"), 
+    lat_actual: Optional[float] = Query(None, description="Latitud actual del vendedor"),
+    lon_actual: Optional[float] = Query(None, description="Longitud actual del vendedor"),
     service: VisitaService = Depends(get_visita_service)
 ):
     """
     Obtiene los detalles completos de una visita por su ID.
     """
     try:
-        visita_detalle = await service.get_visita_detalle_por_id(visita_id)
+        visita_detalle = await service.get_visita_detalle_por_id(visita_id,lat_actual=lat_actual,lon_actual=lon_actual)
         return visita_detalle
     except HTTPException as he:
         raise he

--- a/src/visitas/router/visita_router.py
+++ b/src/visitas/router/visita_router.py
@@ -121,7 +121,7 @@ async def get_detalle_visita(
     summary="Actualizar una visita existente",
     description="""
     Actualiza uno o más campos de una visita.
-    Ideal para marcar una visita como 'TOMADA' y registrar
+    Ideal para marcar una visita como 'REALIZADA' y registrar
     el detalle, la evidencia (URL), y las horas de inicio/fin.
     """
 )

--- a/src/visitas/schemas/visita_schema.py
+++ b/src/visitas/schemas/visita_schema.py
@@ -25,6 +25,11 @@ class CrearRutaVisitaSchema(BaseModel):
     class Config:
         from_attributes = True
 
+class ProductoPreferidoSchema(BaseModel):
+    id_producto: str
+    nombre: str
+    cantidad_total: int
+
 
 class VisitaResponseSchema(BaseModel):
     """Esquema de respuesta para una visita creada o consultada."""
@@ -70,6 +75,10 @@ class VisitaDetalleResponseSchema(VisitaResponseSchema):
     notas_visitas_anteriores: List[NotaVisitaAnteriorSchema] = Field(
         default_factory=list, 
         description="Lista de notas de visitas pasadas del mismo cliente."
+    )
+    productos_preferidos: List[ProductoPreferidoSchema] = Field(
+        default_factory=list,
+        description="Ranking de productos más pedidos por este cliente."
     )
 
     class Config:

--- a/src/visitas/schemas/visita_schema.py
+++ b/src/visitas/schemas/visita_schema.py
@@ -11,6 +11,13 @@ class EstadoVisitaEnum(str, Enum):
     REALIZADA = "REALIZADA"
     CANCELADA = "CANCELADA"
 
+class NotaVisitaAnteriorSchema(BaseModel):
+    fecha_visita_programada: datetime
+    detalle: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
 class CrearRutaVisitaSchema(BaseModel):
     """Esquema de datos requeridos para crear una nueva ruta de visita."""
     cliente_id: UUID4 = Field(..., description="UUID del cliente a visitar.")
@@ -60,6 +67,10 @@ class VisitaDetalleResponseSchema(VisitaResponseSchema):
     """
     nombre_institucion: str = Field(..., description="Nombre del cliente institucional")
     direccion: Optional[str] = Field(None, description="Dirección del cliente")
+    notas_visitas_anteriores: List[NotaVisitaAnteriorSchema] = Field(
+        default_factory=list, 
+        description="Lista de notas de visitas pasadas del mismo cliente."
+    )
 
     class Config:
         from_attributes = True

--- a/src/visitas/schemas/visita_schema.py
+++ b/src/visitas/schemas/visita_schema.py
@@ -8,7 +8,7 @@ from enum import Enum
 class EstadoVisitaEnum(str, Enum):
     """Define los estados permitidos para una visita."""
     PENDIENTE = "PENDIENTE"
-    TOMADA = "TOMADA"
+    REALIZADA = "REALIZADA"
     CANCELADA = "CANCELADA"
 
 class CrearRutaVisitaSchema(BaseModel):
@@ -47,7 +47,7 @@ class RutaVisitaItemSchema(BaseModel):
     nombre: str = Field(..., description="Nombre del cliente institucional")
     direccion: Optional[str] = Field(None, description="Dirección del cliente")
     hora_de_la_cita: str = Field(..., description="Hora de la visita en formato HH:MM (ej: '08:50')")
-    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, TOMADA, CANCELADA)")
+    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, RELIZADA, CANCELADA)")
 
     class Config:
         from_attributes = True
@@ -71,7 +71,7 @@ class ActualizarVisitaSchema(BaseModel):
     cliente_contacto: Optional[str] = Field(None, max_length=100, description="Nombre del contacto en el cliente")
     detalle: Optional[str] = Field(None, max_length=100, description="Detalles o notas de la visita")
     evidencia: Optional[str] = Field(None, max_length=100, description="URL de la foto o video de evidencia")
-    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, TOMADA, CANCELADA)")
+    estado: Optional[EstadoVisitaEnum] = Field(None, description="Nuevo estado de la visita (PENDIENTE, REALIZADA, CANCELADA)")
 
     class Config:
         from_attributes = True

--- a/src/visitas/schemas/visita_schema.py
+++ b/src/visitas/schemas/visita_schema.py
@@ -21,6 +21,10 @@ class NotaVisitaAnteriorSchema(BaseModel):
 class CrearRutaVisitaSchema(BaseModel):
     """Esquema de datos requeridos para crear una nueva ruta de visita."""
     cliente_id: UUID4 = Field(..., description="UUID del cliente a visitar.")
+    fecha_visita_programada: Optional[date] = Field(
+        None, 
+        description="Fecha opcional para la visita (YYYY-MM-DD). Si es None, se usa la lógica de hoy/próximo día hábil."
+    )
 
     class Config:
         from_attributes = True

--- a/src/visitas/schemas/visita_schema.py
+++ b/src/visitas/schemas/visita_schema.py
@@ -72,6 +72,7 @@ class VisitaDetalleResponseSchema(VisitaResponseSchema):
     """
     nombre_institucion: str = Field(..., description="Nombre del cliente institucional")
     direccion: Optional[str] = Field(None, description="Dirección del cliente")
+    cliente_contacto: Optional[str] = Field(None, description="Nombre del contacto en el cliente")
     notas_visitas_anteriores: List[NotaVisitaAnteriorSchema] = Field(
         default_factory=list, 
         description="Lista de notas de visitas pasadas del mismo cliente."
@@ -79,6 +80,10 @@ class VisitaDetalleResponseSchema(VisitaResponseSchema):
     productos_preferidos: List[ProductoPreferidoSchema] = Field(
         default_factory=list,
         description="Ranking de productos más pedidos por este cliente."
+    )
+    tiempo_desplazamiento: Optional[str] = Field(
+        None, 
+        description="Tiempo de viaje estimado desde la ubicación actual del vendedor (ej: '15 min')."
     )
 
     class Config:

--- a/src/visitas/services/visita_service.py
+++ b/src/visitas/services/visita_service.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone, date, timedelta
 import logging
 import httpx 
 import os
-from sqlalchemy import func, Date, cast, desc # <-- AÑADIR 'desc'
+from sqlalchemy import func, Date, cast, desc
 import json
 import random
 import uuid 
@@ -19,7 +19,8 @@ from schemas.visita_schema import (
     RutaVisitaItemSchema, 
     VisitaDetalleResponseSchema, 
     ActualizarVisitaSchema,
-    VisitaResponseSchema
+    VisitaResponseSchema,
+    ProductoPreferidoSchema
 )
 from db.redis_client import get_redis_client
 
@@ -37,6 +38,10 @@ class VisitaService:
         self.ordenes_service_url = os.getenv(
             "ORDENES_QUERIES_SERVICE_URL","http://order-query-api:3000"
         )
+        # API Key de Google
+        self.google_maps_api_key = os.getenv("GOOGLE_MAPS_API_KEY") 
+        if not self.google_maps_api_key:
+            logger.warning("GOOGLE_MAPS_API_KEY no está configurada en las variables de entorno. La optimización de ruta fallará.")
 
     async def _get_cliente_data(self, cliente_id: str) -> Dict[str, Any]:
         """
@@ -47,11 +52,7 @@ class VisitaService:
 
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
-                response = await client.post(
-                    f"{self.clientes_service_url}/api/clientes/by-ids",
-                    json=request_body
-                )
-            
+                response = await client.post(f"{self.clientes_service_url}/api/clientes/by-ids", json=request_body)
             if response.status_code == HTTPStatus.OK:
                 data_list = response.json()
                 if not data_list:
@@ -105,9 +106,7 @@ class VisitaService:
             dias_a_sumar = 0
             if dia_semana == 6: dias_a_sumar = 1
             fecha_base = hoy + timedelta(days=dias_a_sumar)
-            hora_aleatoria = random.randint(8, 18)
-            minuto_aleatorio = random.choice([0, 15, 30, 45])
-            fecha_programada = fecha_base.replace(hour=hora_aleatoria, minute=minuto_aleatorio, second=0, microsecond=0)
+            fecha_programada = fecha_base.replace(hour=0, minute=0, second=0, microsecond=0)
             nueva_visita = Visita(cliente_id=data.cliente_id, vendedor_id=vendedor_id_uuid, fecha_visita_programada=fecha_programada)
             self.db.add(nueva_visita)
             self.db.commit()
@@ -139,43 +138,162 @@ class VisitaService:
             return []
         
         
+    # --- FUNCIÓN TOTALMENTE REEMPLAZADA ---
     async def get_rutas_por_fecha_y_vendedor(
         self, 
         fecha: date, 
-        vendedor_id: uuid.UUID  
+        vendedor_id: uuid.UUID,
+        lat_actual: Optional[float] = None,
+        lon_actual: Optional[float] = None
     ) -> List[RutaVisitaItemSchema]:
         """
-        Obtiene la lista de visitas programadas para un VENDEDOR 
-        en una FECHA específica, enriquecidas con datos del cliente 
-        y ordenadas por hora.
+        Obtiene la lista de todas las visitas del día (Pendientes, Realizadas, Canceladas).
+        Si se provee lat/lon, optimiza la ruta de las PENDIENTES y
+        devuelve el tiempo de viaje. Las otras se añaden al final.
         """
         try:
-            visitas_db = self.db.query(Visita).filter(
+            # 1. Obtener visitas PENDIENTES (para optimizar)
+            visitas_pendientes_db = self.db.query(Visita).filter(
                 func.cast(Visita.fecha_visita_programada, Date) == fecha,
-                Visita.vendedor_id == vendedor_id 
+                Visita.vendedor_id == vendedor_id,
+                Visita.estado == "PENDIENTE"
+            ).all()
+
+            # 2. Obtener visitas REALIZADAS y CANCELADAS (para el final de la lista)
+            visitas_otras_db = self.db.query(Visita).filter(
+                func.cast(Visita.fecha_visita_programada, Date) == fecha,
+                Visita.vendedor_id == vendedor_id,
+                Visita.estado.in_(['REALIZADA', 'CANCELADA'])
             ).order_by(Visita.fecha_visita_programada.asc()).all()
-            if not visitas_db: return [] 
-            cliente_ids = list(set(str(v.cliente_id) for v in visitas_db))
+
+            # 3. Obtener datos de clientes (para todas las visitas)
+            all_visitas_db = visitas_pendientes_db + visitas_otras_db
+            if not all_visitas_db:
+                return [] 
+
+            cliente_ids = list(set(str(v.cliente_id) for v in all_visitas_db))
             clientes_data_list = await self._get_clientes_batch_data(cliente_ids)
             clientes_map = {c["id"]: c for c in clientes_data_list}
+
+            # 4. Preparar datos para la lista de PENDIENTES
+            visitas_para_procesar = []
+            for v in visitas_pendientes_db:
+                cliente_info = clientes_map.get(str(v.cliente_id), {})
+                visitas_para_procesar.append({
+                    "visita_obj": v,
+                    "cliente_info": cliente_info
+                })
+
+            # 5. Lógica de Optimización (solo para PENDIENTES)
+            lista_optimizada_items = []
+            
+            if lat_actual is not None and lon_actual is not None and self.google_maps_api_key:
+                
+                origen = f"{lat_actual},{lon_actual}"
+                waypoints_coords = []
+                visitas_map = {} 
+                
+                for item in visitas_para_procesar:
+                    direccion = item["cliente_info"].get("address", "")
+                    coords = direccion.split(",")
+                    if len(coords) >= 3 and coords[0] != "NA" and coords[1] != "NA":
+                        try:
+                            float(coords[0])
+                            float(coords[1])
+                            coord_str = f"{coords[0]},{coords[1]}"
+                            waypoints_coords.append(coord_str)
+                            visitas_map[coord_str] = item
+                        except ValueError:
+                             logger.warning(f"Coordenadas inválidas para visita {item['visita_obj'].id}: {direccion}")
+                    
+                
+                if not waypoints_coords:
+                    logger.warning("Ruta del día: Hay visitas pendientes pero ninguna tiene coordenadas válidas.")
+                    lista_optimizada_items = visitas_para_procesar 
+                
+                else:
+                    async with httpx.AsyncClient(timeout=10.0) as client:
+                        params = {
+                            "origin": origen,
+                            "destination": origen,
+                            "waypoints": f"optimize:true|{'|'.join(waypoints_coords)}",
+                            "key": self.google_maps_api_key,
+                            "units": "metric"
+                        }
+                        response = await client.get("https://maps.googleapis.com/maps/api/directions/json", params=params)
+                    
+                    if response.status_code == HTTPStatus.OK:
+                        route_data = response.json()
+                        if route_data.get("routes") and route_data.get("status") == "OK":
+                            route = route_data["routes"][0]
+                            waypoint_order = route.get("waypoint_order", []) 
+                            legs = route.get("legs", []) 
+                            
+                            visitas_ordenadas = [visitas_map[waypoints_coords[i]] for i in waypoint_order]
+                            
+                            if legs:
+                                item = visitas_ordenadas[0]
+                                item["travel_time"] = legs[0].get("duration", {}).get("text", "N/A")
+                                lista_optimizada_items.append(item)
+                            
+                            for i, leg in enumerate(legs[1:], start=1):
+                                if i < len(visitas_ordenadas):
+                                    item = visitas_ordenadas[i]
+                                    item["travel_time"] = leg.get("duration", {}).get("text", "N/A")
+                                    lista_optimizada_items.append(item)
+                        else:
+                            logger.warning(f"Google Maps no pudo calcular la ruta: {route_data.get('status')}")
+                            lista_optimizada_items = visitas_para_procesar
+                    else:
+                        logger.error(f"Error de Google Maps API: {response.text}")
+                        lista_optimizada_items = visitas_para_procesar
+            else:
+                if not self.google_maps_api_key:
+                    logger.warning("No se optimizó la ruta: GOOGLE_MAPS_API_KEY no está configurada.")
+                else:
+                    logger.info("No se optimizó la ruta: Faltan lat_actual o lon_actual.")
+                lista_optimizada_items = visitas_para_procesar
+
+            # 6. Construir la respuesta final
             resultados = []
-            for visita in visitas_db:
-                cliente_id_str = str(visita.cliente_id)
-                cliente_info = clientes_map.get(cliente_id_str, {})
-                hora_formateada = visita.fecha_visita_programada.strftime("%H:%M")
-                item = RutaVisitaItemSchema(
+            
+            # 6.1. Añadir las visitas PENDIENTES (optimizadas o no)
+            for item in lista_optimizada_items:
+                visita = item["visita_obj"]
+                cliente_info = item["cliente_info"]
+                hora_o_tiempo = item.get("travel_time", "Sin calcular") 
+                
+                schema_item = RutaVisitaItemSchema(
                     id=visita.id,
                     cliente_id=visita.cliente_id,
                     nombre=cliente_info.get("nombre", "Cliente no encontrado"),
                     direccion=cliente_info.get("address", "Dirección no disponible"),
-                    hora_de_la_cita=hora_formateada,
+                    hora_de_la_cita=hora_o_tiempo,
                     estado=visita.estado
                 )
-                resultados.append(item)
+                resultados.append(schema_item)
+
+            # 6.2. Añadir las visitas REALIZADAS y CANCELADAS al final
+            for visita in visitas_otras_db:
+                cliente_info = clientes_map.get(str(visita.cliente_id), {})
+                
+                schema_item = RutaVisitaItemSchema(
+                    id=visita.id,
+                    cliente_id=visita.cliente_id,
+                    nombre=cliente_info.get("nombre", "Cliente no encontrado"),
+                    direccion=cliente_info.get("address", "Dirección no disponible"),
+                    hora_de_la_cita="N/A",
+                    estado=visita.estado
+                )
+                resultados.append(schema_item)
             return resultados
         except Exception as e:
             self.db.rollback()
-            raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Error interno al obtener las rutas de visita.")
+            logger.error(f"Error al obtener rutas por fecha y vendedor: {e}")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al obtener las rutas de visita."
+            )
         
     async def get_visita_detalle_por_id(self, visita_id: uuid.UUID) -> VisitaDetalleResponseSchema:
         """
@@ -184,15 +302,9 @@ class VisitaService:
         las notas de visitas anteriores.
         """
         try:
-            visita_db = self.db.query(Visita).filter(
-                Visita.id == visita_id
-            ).first()
-
+            visita_db = self.db.query(Visita).filter(Visita.id == visita_id).first()
             if not visita_db:
-                raise HTTPException(
-                    status_code=HTTPStatus.NOT_FOUND,
-                    detail=f"Visita con ID {visita_id} no encontrada."
-                )
+                raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=f"Visita con ID {visita_id} no encontrada.")
 
             cliente_id_str = str(visita_db.cliente_id)
             try:
@@ -204,16 +316,13 @@ class VisitaService:
                 direccion_cliente = "Dirección no disponible"
 
             visitas_anteriores_db = self.db.query(
-                Visita.fecha_visita_programada,
-                Visita.detalle
+                Visita.fecha_visita_programada, Visita.detalle
             ).filter(
                 Visita.cliente_id == visita_db.cliente_id, 
                 Visita.id != visita_id,                     
                 Visita.detalle.isnot(None),             
                 Visita.estado.in_(['REALIZADA', 'CANCELADA']) 
-            ).order_by(
-                desc(Visita.fecha_visita_programada)      
-            ).limit(5).all() 
+            ).order_by(desc(Visita.fecha_visita_programada)).limit(5).all() 
             
             notas_anteriores_list = [
                 {"fecha_visita_programada": v.fecha_visita_programada, "detalle": v.detalle}
@@ -221,9 +330,7 @@ class VisitaService:
             ]
 
             top_products_list = await self._get_top_products_data(cliente_id_str)
-            # -----------------------------------------------
 
-            # 4. Combinar todo
             visita_dict = visita_db.to_dict()
             visita_dict["nombre_institucion"] = nombre_cliente
             visita_dict["direccion"] = direccion_cliente

--- a/src/visitas/services/visita_service.py
+++ b/src/visitas/services/visita_service.py
@@ -153,33 +153,83 @@ class VisitaService:
         
 
     async def crear_ruta_visita(self, data: CrearRutaVisitaSchema) -> Dict[str, Any]:
+        """
+        Crea un nuevo registro de visita (ruta).
+        1. Valida el cliente_id.
+        2. Extrae el vendedor_id.
+        3. Asigna la fecha: usa la fecha provista o calcula la de hoy/próximo día hábil.
+        """
+        
         cliente_data = await self._get_cliente_data(str(data.cliente_id))
+        
         vendedor_id_str = cliente_data.get("id_vendedor")
+        
         if not vendedor_id_str:
-            raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=f"El cliente {data.cliente_id} no tiene un vendedor asignado.")
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail=f"El cliente {data.cliente_id} no tiene un vendedor asignado."
+            )
+        
         try:
             vendedor_id_uuid = uuid.UUID(vendedor_id_str)
         except ValueError:
-            raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="El ID del vendedor recibido del servicio de clientes no es válido.")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="El ID del vendedor recibido del servicio de clientes no es válido."
+            )
+
         try:
-            hoy = datetime.now(timezone.utc)
-            dia_semana = hoy.weekday()
-            dias_a_sumar = 0
-            if dia_semana == 6: dias_a_sumar = 1
-            fecha_base = hoy + timedelta(days=dias_a_sumar)
-            fecha_programada = fecha_base.replace(hour=0, minute=0, second=0, microsecond=0)
-            nueva_visita = Visita(cliente_id=data.cliente_id, vendedor_id=vendedor_id_uuid, fecha_visita_programada=fecha_programada)
+            if data.fecha_visita_programada:
+                fecha_programada = datetime.combine(
+                    data.fecha_visita_programada, 
+                    datetime.min.time()
+                ).replace(tzinfo=timezone.utc)
+                
+                logger.info(f"Creando visita con fecha proporcionada: {fecha_programada}")
+
+            else:
+                hoy = datetime.now(timezone.utc)
+                dia_semana = hoy.weekday() 
+                dias_a_sumar = 0
+                if dia_semana == 6:
+                    dias_a_sumar = 1 
+                
+                fecha_base = hoy + timedelta(days=dias_a_sumar)
+
+                fecha_programada = fecha_base.replace(
+                    hour=0, 
+                    minute=0, 
+                    second=0, 
+                    microsecond=0
+                )
+                logger.info(f"Creando visita con fecha calculada (hoy/próx. día hábil): {fecha_programada}")
+
+            nueva_visita = Visita(
+                cliente_id=data.cliente_id,
+                vendedor_id=vendedor_id_uuid, 
+                fecha_visita_programada=fecha_programada
+            )
+            
             self.db.add(nueva_visita)
             self.db.commit()
             self.db.refresh(nueva_visita)
+            
             logger.info(f"Nueva ruta de visita creada con ID: {nueva_visita.id}")
             return nueva_visita.to_dict()
+            
         except IntegrityError as ie:
             self.db.rollback()
-            raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="Error de integridad. Verifique los IDs.")
+            raise HTTPException(
+                status_code=HTTPStatus.CONFLICT,
+                detail="Error de integridad. Verifique los IDs."
+            )
         except Exception as e:
             self.db.rollback()
-            raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Error interno al crear la ruta de visita.")
+            raise HTTPException(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                detail="Error interno al crear la ruta de visita."
+            )
+        
         
     async def _get_clientes_batch_data(self, cliente_ids: List[str]) -> List[Dict[str, Any]]:
         """

--- a/src/visitas/services/visita_service.py
+++ b/src/visitas/services/visita_service.py
@@ -67,16 +67,15 @@ class VisitaService:
         Llama al servicio de Órdenes para obtener el Top 5 de productos.
         Usa el endpoint público (pasando client_id como query param).
         """
-        # Este es el endpoint que acabas de crear en el router de órdenes
         endpoint_url = f"{self.ordenes_service_url}/orders/client-top-products"
-        params = {"client_id": cliente_id, "limit": 5} # Traemos el Top 5
+        params = {"client_id": cliente_id, "limit": 5} 
 
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(endpoint_url, params=params)
             
             if response.status_code == HTTPStatus.OK:
-                return response.json().get("data", []) # Devuelve la lista "data"
+                return response.json().get("data", []) 
             else:
                 logger.error(f"Error del servicio de órdenes ({endpoint_url}): {response.status_code} - {response.text}")
                 return []

--- a/src/visitas/services/visita_service.py
+++ b/src/visitas/services/visita_service.py
@@ -34,7 +34,9 @@ class VisitaService:
         self.clientes_service_url = os.getenv(
             "CLIENTES_SERVICE_URL", "http://clientes-service:3000"
         )
-        # ---------------
+        self.ordenes_service_url = os.getenv(
+            "ORDENES_QUERIES_SERVICE_URL","http://order-query-api:3000"
+        )
 
     async def _get_cliente_data(self, cliente_id: str) -> Dict[str, Any]:
         """
@@ -60,7 +62,28 @@ class VisitaService:
         except httpx.RequestError as e:
             raise HTTPException(status_code=HTTPStatus.SERVICE_UNAVAILABLE, detail="No se pudo conectar con el servicio de clientes.")
 
+    async def _get_top_products_data(self, cliente_id: str) -> List[Dict[str, Any]]:
+        """
+        Llama al servicio de Órdenes para obtener el Top 5 de productos.
+        Usa el endpoint público (pasando client_id como query param).
+        """
+        # Este es el endpoint que acabas de crear en el router de órdenes
+        endpoint_url = f"{self.ordenes_service_url}/orders/client-top-products"
+        params = {"client_id": cliente_id, "limit": 5} # Traemos el Top 5
 
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(endpoint_url, params=params)
+            
+            if response.status_code == HTTPStatus.OK:
+                return response.json().get("data", []) # Devuelve la lista "data"
+            else:
+                logger.error(f"Error del servicio de órdenes ({endpoint_url}): {response.status_code} - {response.text}")
+                return []
+        except httpx.RequestError as e:
+            logger.error(f"Error de conexión al servicio de órdenes ({endpoint_url}): {e}")
+            return []
+        
     async def crear_ruta_visita(self, data: CrearRutaVisitaSchema) -> Dict[str, Any]:
         """
         Crea un nuevo registro de visita (ruta).
@@ -197,6 +220,8 @@ class VisitaService:
                 {"fecha_visita_programada": v.fecha_visita_programada, "detalle": v.detalle}
                 for v in visitas_anteriores_db
             ]
+
+            top_products_list = await self._get_top_products_data(cliente_id_str)
             # -----------------------------------------------
 
             # 4. Combinar todo
@@ -204,6 +229,7 @@ class VisitaService:
             visita_dict["nombre_institucion"] = nombre_cliente
             visita_dict["direccion"] = direccion_cliente
             visita_dict["notas_visitas_anteriores"] = notas_anteriores_list 
+            visita_dict["productos_preferidos"] = top_products_list
 
             return VisitaDetalleResponseSchema(**visita_dict)
 

--- a/src/visitas/services/visita_service.py
+++ b/src/visitas/services/visita_service.py
@@ -38,10 +38,13 @@ class VisitaService:
         self.ordenes_service_url = os.getenv(
             "ORDENES_QUERIES_SERVICE_URL","http://order-query-api:3000"
         )
-        # API Key de Google
-        self.google_maps_api_key = os.getenv("GOOGLE_MAPS_API_KEY") 
+        self.google_maps_api_key = 'AIzaSyDb6LS5PiW2HmwoCmwDN2BTjoaxGiB9EGU'
         if not self.google_maps_api_key:
             logger.warning("GOOGLE_MAPS_API_KEY no está configurada en las variables de entorno. La optimización de ruta fallará.")
+
+        self.auth_service_url = os.getenv(
+            "AUTH_SERVICE_URL", "http://autenticacion-service:3000" 
+        )
 
     async def _get_cliente_data(self, cliente_id: str) -> Dict[str, Any]:
         """
@@ -83,15 +86,73 @@ class VisitaService:
         except httpx.RequestError as e:
             logger.error(f"Error de conexión al servicio de órdenes ({endpoint_url}): {e}")
             return []
-        
-    async def crear_ruta_visita(self, data: CrearRutaVisitaSchema) -> Dict[str, Any]:
-        """
-        Crea un nuevo registro de visita (ruta).
-        1. Valida el cliente_id llamando al servicio de Clientes.
-        2. Extrae el vendedor_id de la respuesta del cliente.
-        3. Genera una fecha de visita programada aleatoria para hoy.
-        """
 
+
+    async def _get_single_route_travel_time(
+        self, 
+        origin_coords: str, 
+        destination_coords: str
+    ) -> Optional[str]:
+        """
+        Llama a Google Maps Directions API para obtener el tiempo de viaje
+        de un solo tramo (Punto A a Punto B).
+        """
+        if not self.google_maps_api_key:
+            logger.warning("No se puede calcular tiempo de viaje: GOOGLE_MAPS_API_KEY no está configurada.")
+            return None
+            
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                params = {
+                    "origin": origin_coords,
+                    "destination": destination_coords,
+                    "key": self.google_maps_api_key,
+                    "units": "metric"
+                }
+                response = await client.get("https://maps.googleapis.com/maps/api/directions/json", params=params)
+            
+            if response.status_code == HTTPStatus.OK:
+                route_data = response.json()
+                if route_data.get("routes") and route_data.get("status") == "OK":
+                    leg = route_data["routes"][0].get("legs", [{}])[0]
+                    travel_time = leg.get("duration", {}).get("text", None)
+                    return travel_time
+                else:
+                    logger.warning(f"Google Maps no pudo calcular la ruta A->B: {route_data.get('status')}")
+                    return None
+            else:
+                logger.error(f"Error de Google Maps API (ruta A->B): {response.text}")
+                return None
+        except Exception as e:
+            logger.error(f"Error de httpx al llamar a Google Maps (ruta A->B): {e}")
+            return None
+        
+    async def _get_user_contact_for_client(self, cliente_id: str) -> Optional[str]:
+        """
+        Llama al servicio de Usuarios para obtener el 'username'
+        asociado a un 'id_client'.
+        """
+        endpoint_url = f"{self.auth_service_url}/auth/user-by-client/{cliente_id}"
+        
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(endpoint_url)
+            
+            if response.status_code == HTTPStatus.OK:
+                user_data = response.json()
+                return user_data.get("username") 
+            elif response.status_code == HTTPStatus.NOT_FOUND:
+                logger.warning(f"No se encontró usuario para el cliente {cliente_id} en {endpoint_url}")
+                return None
+            else:
+                logger.error(f"Error del servicio de usuarios ({endpoint_url}): {response.status_code} - {response.text}")
+                return None
+        except httpx.RequestError as e:
+            logger.error(f"Error de conexión al servicio de usuarios ({endpoint_url}): {e}")
+            return None
+        
+
+    async def crear_ruta_visita(self, data: CrearRutaVisitaSchema) -> Dict[str, Any]:
         cliente_data = await self._get_cliente_data(str(data.cliente_id))
         vendedor_id_str = cliente_data.get("id_vendedor")
         if not vendedor_id_str:
@@ -138,7 +199,6 @@ class VisitaService:
             return []
         
         
-    # --- FUNCIÓN TOTALMENTE REEMPLAZADA ---
     async def get_rutas_por_fecha_y_vendedor(
         self, 
         fecha: date, 
@@ -295,11 +355,16 @@ class VisitaService:
                 detail="Error interno al obtener las rutas de visita."
             )
         
-    async def get_visita_detalle_por_id(self, visita_id: uuid.UUID) -> VisitaDetalleResponseSchema:
+    async def get_visita_detalle_por_id(
+        self, 
+        visita_id: uuid.UUID,
+        lat_actual: Optional[float] = None, 
+        lon_actual: Optional[float] = None  
+    ) -> VisitaDetalleResponseSchema:
         """
         Obtiene todos los detalles de una visita específica,
-        enriquecidos con datos del cliente (nombre, dirección) Y
-        las notas de visitas anteriores.
+        enriquecidos con datos del cliente Y notas Y productos preferidos
+        Y el tiempo de viaje si se provee ubicación.
         """
         try:
             visita_db = self.db.query(Visita).filter(Visita.id == visita_id).first()
@@ -330,12 +395,29 @@ class VisitaService:
             ]
 
             top_products_list = await self._get_top_products_data(cliente_id_str)
+            nombre_contacto = await self._get_user_contact_for_client(cliente_id_str)
 
+            tiempo_desplazamiento = None
+            if lat_actual is not None and lon_actual is not None and direccion_cliente:
+                coords = direccion_cliente.split(",")
+                if len(coords) >= 3 and coords[0] != "NA" and coords[1] != "NA":
+                    try:
+                        float(coords[0])
+                        float(coords[1])
+                        origen = f"{lat_actual},{lon_actual}"
+                        destino = f"{coords[0]},{coords[1]}"
+                        
+                        tiempo_desplazamiento = await self._get_single_route_travel_time(origen, destino)
+                        
+                    except (ValueError, TypeError):
+                            logger.warning(f"No se pudo calcular tiempo de viaje para visita {visita_id}: coordenadas inválidas.")
             visita_dict = visita_db.to_dict()
             visita_dict["nombre_institucion"] = nombre_cliente
             visita_dict["direccion"] = direccion_cliente
             visita_dict["notas_visitas_anteriores"] = notas_anteriores_list 
             visita_dict["productos_preferidos"] = top_products_list
+            visita_dict["tiempo_desplazamiento"] = tiempo_desplazamiento 
+            visita_dict["cliente_contacto"] = nombre_contacto
 
             return VisitaDetalleResponseSchema(**visita_dict)
 

--- a/src/visitas/services/visita_service.py
+++ b/src/visitas/services/visita_service.py
@@ -7,14 +7,20 @@ from datetime import datetime, timezone, date, timedelta
 import logging
 import httpx 
 import os
-from sqlalchemy import func, Date, cast
+from sqlalchemy import func, Date, cast, desc # <-- AÑADIR 'desc'
 import json
 import random
 import uuid 
 
 from db.database import get_db
 from db.visita import Visita
-from schemas.visita_schema import CrearRutaVisitaSchema, RutaVisitaItemSchema, VisitaDetalleResponseSchema, ActualizarVisitaSchema
+from schemas.visita_schema import (
+    CrearRutaVisitaSchema, 
+    RutaVisitaItemSchema, 
+    VisitaDetalleResponseSchema, 
+    ActualizarVisitaSchema,
+    VisitaResponseSchema
+)
 from db.redis_client import get_redis_client
 
 logger = logging.getLogger(__name__)
@@ -36,7 +42,7 @@ class VisitaService:
         usando el endpoint /by-ids.
         """
         request_body = {"ids": [cliente_id]}
-        
+
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.post(
@@ -47,25 +53,12 @@ class VisitaService:
             if response.status_code == HTTPStatus.OK:
                 data_list = response.json()
                 if not data_list:
-                    logger.warning(f"Intento de crear visita para cliente inexistente: {cliente_id}")
-                    raise HTTPException(
-                        status_code=HTTPStatus.NOT_FOUND,
-                        detail=f"Cliente con ID {cliente_id} no encontrado."
-                    )
+                    raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=f"Cliente con ID {cliente_id} no encontrado.")
                 return data_list[0]
             else:
-                logger.error(f"Error del servicio de clientes: {response.status_code} - {response.text}")
-                raise HTTPException(
-                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
-                    detail="Error al comunicarse con el servicio de clientes."
-                )
-        
+                raise HTTPException(status_code=HTTPStatus.SERVICE_UNAVAILABLE, detail="Error al comunicarse con el servicio de clientes.")
         except httpx.RequestError as e:
-            logger.error(f"Error de conexión al servicio de clientes: {e}")
-            raise HTTPException(
-                status_code=HTTPStatus.SERVICE_UNAVAILABLE,
-                detail="No se pudo conectar con el servicio de clientes."
-            )
+            raise HTTPException(status_code=HTTPStatus.SERVICE_UNAVAILABLE, detail="No se pudo conectar con el servicio de clientes.")
 
 
     async def crear_ruta_visita(self, data: CrearRutaVisitaSchema) -> Dict[str, Any]:
@@ -75,99 +68,52 @@ class VisitaService:
         2. Extrae el vendedor_id de la respuesta del cliente.
         3. Genera una fecha de visita programada aleatoria para hoy.
         """
-        
+
         cliente_data = await self._get_cliente_data(str(data.cliente_id))
-        
         vendedor_id_str = cliente_data.get("id_vendedor")
-        
         if not vendedor_id_str:
-            logger.warning(f"Cliente {data.cliente_id} no tiene vendedor asignado.")
-            raise HTTPException(
-                status_code=HTTPStatus.BAD_REQUEST,
-                detail=f"El cliente {data.cliente_id} no tiene un vendedor asignado."
-            )
-        
+            raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=f"El cliente {data.cliente_id} no tiene un vendedor asignado.")
         try:
             vendedor_id_uuid = uuid.UUID(vendedor_id_str)
         except ValueError:
-            logger.error(f"El id_vendedor '{vendedor_id_str}' no es un UUID válido.")
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                detail="El ID del vendedor recibido del servicio de clientes no es válido."
-            )
-
+            raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="El ID del vendedor recibido del servicio de clientes no es válido.")
         try:
             hoy = datetime.now(timezone.utc)
             dia_semana = hoy.weekday()
             dias_a_sumar = 0
-            if dia_semana == 6:
-                dias_a_sumar = 1
-            
+            if dia_semana == 6: dias_a_sumar = 1
             fecha_base = hoy + timedelta(days=dias_a_sumar)
-
             hora_aleatoria = random.randint(8, 18)
             minuto_aleatorio = random.choice([0, 15, 30, 45])
-            
-            fecha_programada = fecha_base.replace(
-                hour=hora_aleatoria, 
-                minute=minuto_aleatorio, 
-                second=0, 
-                microsecond=0
-            )
-
-            nueva_visita = Visita(
-                cliente_id=data.cliente_id,
-                vendedor_id=vendedor_id_uuid, 
-                fecha_visita_programada=fecha_programada
-            )
-            
+            fecha_programada = fecha_base.replace(hour=hora_aleatoria, minute=minuto_aleatorio, second=0, microsecond=0)
+            nueva_visita = Visita(cliente_id=data.cliente_id, vendedor_id=vendedor_id_uuid, fecha_visita_programada=fecha_programada)
             self.db.add(nueva_visita)
             self.db.commit()
             self.db.refresh(nueva_visita)
-            
             logger.info(f"Nueva ruta de visita creada con ID: {nueva_visita.id}")
             return nueva_visita.to_dict()
-            
         except IntegrityError as ie:
             self.db.rollback()
-            logger.error(f"Integrity error creating visita: {ie}")
-            raise HTTPException(
-                status_code=HTTPStatus.CONFLICT,
-                detail="Error de integridad. Verifique los IDs."
-            )
+            raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="Error de integridad. Verifique los IDs.")
         except Exception as e:
             self.db.rollback()
-            logger.error(f"Error creating visita: {e}")
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                detail="Error interno al crear la ruta de visita."
-            )
+            raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Error interno al crear la ruta de visita.")
         
     async def _get_clientes_batch_data(self, cliente_ids: List[str]) -> List[Dict[str, Any]]:
         """
         Llama al servicio de Clientes para obtener los datos de múltiples clientes
         usando el endpoint /by-ids.
         """
-        if not cliente_ids:
-            return []
-            
+        if not cliente_ids: return []
         request_body = {"ids": cliente_ids}
-        
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
-                response = await client.post(
-                    f"{self.clientes_service_url}/api/clientes/by-ids",
-                    json=request_body
-                )
-            
+                response = await client.post(f"{self.clientes_service_url}/api/clientes/by-ids", json=request_body)
             if response.status_code == HTTPStatus.OK:
                 return response.json() 
             else:
-                logger.error(f"Error del servicio de clientes: {response.status_code} - {response.text}")
                 return []
-        
         except httpx.RequestError as e:
-            logger.error(f"Error de conexión al servicio de clientes: {e}")
             return []
         
         
@@ -185,24 +131,16 @@ class VisitaService:
             visitas_db = self.db.query(Visita).filter(
                 func.cast(Visita.fecha_visita_programada, Date) == fecha,
                 Visita.vendedor_id == vendedor_id 
-            ).order_by(
-                Visita.fecha_visita_programada.asc()
-            ).all()
-
-            if not visitas_db:
-                return [] 
-
+            ).order_by(Visita.fecha_visita_programada.asc()).all()
+            if not visitas_db: return [] 
             cliente_ids = list(set(str(v.cliente_id) for v in visitas_db))
-            
             clientes_data_list = await self._get_clientes_batch_data(cliente_ids)
             clientes_map = {c["id"]: c for c in clientes_data_list}
-
             resultados = []
             for visita in visitas_db:
                 cliente_id_str = str(visita.cliente_id)
                 cliente_info = clientes_map.get(cliente_id_str, {})
                 hora_formateada = visita.fecha_visita_programada.strftime("%H:%M")
-                
                 item = RutaVisitaItemSchema(
                     id=visita.id,
                     cliente_id=visita.cliente_id,
@@ -212,21 +150,16 @@ class VisitaService:
                     estado=visita.estado
                 )
                 resultados.append(item)
-
             return resultados
-
         except Exception as e:
             self.db.rollback()
-            logger.error(f"Error al obtener rutas por fecha y vendedor: {e}")
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                detail="Error interno al obtener las rutas de visita."
-            )
+            raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Error interno al obtener las rutas de visita.")
         
     async def get_visita_detalle_por_id(self, visita_id: uuid.UUID) -> VisitaDetalleResponseSchema:
         """
         Obtiene todos los detalles de una visita específica,
-        enriquecidos con datos del cliente (nombre, dirección).
+        enriquecidos con datos del cliente (nombre, dirección) Y
+        las notas de visitas anteriores.
         """
         try:
             visita_db = self.db.query(Visita).filter(
@@ -248,10 +181,29 @@ class VisitaService:
                 nombre_cliente = "Cliente no disponible"
                 direccion_cliente = "Dirección no disponible"
 
-            visita_dict = visita_db.to_dict()
+            visitas_anteriores_db = self.db.query(
+                Visita.fecha_visita_programada,
+                Visita.detalle
+            ).filter(
+                Visita.cliente_id == visita_db.cliente_id, 
+                Visita.id != visita_id,                     
+                Visita.detalle.isnot(None),             
+                Visita.estado.in_(['REALIZADA', 'CANCELADA']) 
+            ).order_by(
+                desc(Visita.fecha_visita_programada)      
+            ).limit(5).all() 
+            
+            notas_anteriores_list = [
+                {"fecha_visita_programada": v.fecha_visita_programada, "detalle": v.detalle}
+                for v in visitas_anteriores_db
+            ]
+            # -----------------------------------------------
 
+            # 4. Combinar todo
+            visita_dict = visita_db.to_dict()
             visita_dict["nombre_institucion"] = nombre_cliente
             visita_dict["direccion"] = direccion_cliente
+            visita_dict["notas_visitas_anteriores"] = notas_anteriores_list 
 
             return VisitaDetalleResponseSchema(**visita_dict)
 
@@ -275,41 +227,20 @@ class VisitaService:
         Aplica validación de transiciones de estado.
         """
         try:
-            visita_db = self.db.query(Visita).filter(
-                Visita.id == visita_id
-            ).first()
-
+            visita_db = self.db.query(Visita).filter(Visita.id == visita_id).first()
             if not visita_db:
-                raise HTTPException(
-                    status_code=HTTPStatus.NOT_FOUND,
-                    detail=f"Visita con ID {visita_id} no encontrada."
-                )
-
+                raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=f"Visita con ID {visita_id} no encontrada.")
             update_data = data.model_dump(exclude_unset=True)
-
             if not update_data:
-                raise HTTPException(
-                    status_code=HTTPStatus.BAD_REQUEST,
-                    detail="No se proporcionaron datos para actualizar."
-                )
+                raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="No se proporcionaron datos para actualizar.")
 
             nuevo_estado = update_data.get("estado")
+            estado_actual = visita_db.estado
             
             if nuevo_estado:
-                estado_actual = visita_db.estado
-                
-                if estado_actual in ("REALIZADA", "CANCELADA"):
-                    
-                    if nuevo_estado != estado_actual:
-                        logger.warning(
-                            f"Intento bloqueado: Cambiar visita {visita_id} de '{estado_actual}' a '{nuevo_estado}'."
-                        )
-                        raise HTTPException(
-                            status_code=HTTPStatus.BAD_REQUEST,
-                            detail=f"No se puede cambiar el estado de una visita que ya está '{estado_actual}'."
-                        )
-                
-
+                if estado_actual in ("REALIZADA", "CANCELADA") and nuevo_estado != estado_actual:
+                    raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=f"No se puede cambiar el estado de una visita que ya está '{estado_actual}'.")
+            
             for key, value in update_data.items():
                 setattr(visita_db, key, value)
             
@@ -317,55 +248,35 @@ class VisitaService:
 
             if nuevo_estado == "CANCELADA" and estado_actual != "CANCELADA":
                 fecha_origen = visita_db.fecha_visita_programada
-                
                 if fecha_origen.tzinfo is None:
                     fecha_origen = fecha_origen.replace(tzinfo=timezone.utc)
-
                 dia_semana = fecha_origen.weekday()
                 dias_a_sumar = 1
-
-                if dia_semana == 5:
-                    dias_a_sumar = 2
-                elif dia_semana == 6:
-                    dias_a_sumar = 1
-
+                if dia_semana == 5: dias_a_sumar = 2
+                elif dia_semana == 6: dias_a_sumar = 1
                 fecha_nueva_base = fecha_origen + timedelta(days=dias_a_sumar)
-
                 hora_aleatoria = random.randint(8, 18)
                 minuto_aleatorio = random.choice([0, 15, 30, 45])
-                
-                fecha_reprogramada = fecha_nueva_base.replace(
-                    hour=hora_aleatoria, 
-                    minute=minuto_aleatorio, 
-                    second=0, 
-                    microsecond=0
-                )
-
+                fecha_reprogramada = fecha_nueva_base.replace(hour=hora_aleatoria, minute=minuto_aleatorio, second=0, microsecond=0)
                 nueva_visita_reprogramada = Visita(
                     cliente_id=visita_db.cliente_id,
                     vendedor_id=visita_db.vendedor_id,
                     fecha_visita_programada=fecha_reprogramada,
                     estado="PENDIENTE"
                 )
-                
                 self.db.add(nueva_visita_reprogramada)
                 logger.info(f"Visita {visita_id} cancelada. Reprogramada para: {fecha_reprogramada}")
 
             self.db.commit()
             self.db.refresh(visita_db)
-
             return await self.get_visita_detalle_por_id(visita_id)
-
         except HTTPException as he:
             self.db.rollback()
             raise he
         except Exception as e:
             self.db.rollback()
             logger.error(f"Error al actualizar visita {visita_id}: {e}")
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                detail="Error interno al actualizar la visita."
-            )
+            raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Error interno al actualizar la visita.")
 
 def get_visita_service(db: Session = Depends(get_db)) -> VisitaService:
     return VisitaService(db)

--- a/src/visitas/services/visita_service.py
+++ b/src/visitas/services/visita_service.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from fastapi import Depends, HTTPException
 from http import HTTPStatus
-from datetime import datetime, timezone, date
+from datetime import datetime, timezone, date, timedelta 
 import logging
 import httpx 
 import os
@@ -98,10 +98,17 @@ class VisitaService:
 
         try:
             hoy = datetime.now(timezone.utc)
-            hora_aleatoria = random.randint(8, 17)
+            dia_semana = hoy.weekday()
+            dias_a_sumar = 0
+            if dia_semana == 6:
+                dias_a_sumar = 1
+            
+            fecha_base = hoy + timedelta(days=dias_a_sumar)
+
+            hora_aleatoria = random.randint(8, 18)
             minuto_aleatorio = random.choice([0, 15, 30, 45])
             
-            fecha_programada = hoy.replace(
+            fecha_programada = fecha_base.replace(
                 hour=hora_aleatoria, 
                 minute=minuto_aleatorio, 
                 second=0, 
@@ -307,10 +314,46 @@ class VisitaService:
                 setattr(visita_db, key, value)
             
             self.db.add(visita_db)
+
+            if nuevo_estado == "CANCELADA" and estado_actual != "CANCELADA":
+                fecha_origen = visita_db.fecha_visita_programada
+                
+                if fecha_origen.tzinfo is None:
+                    fecha_origen = fecha_origen.replace(tzinfo=timezone.utc)
+
+                dia_semana = fecha_origen.weekday()
+                dias_a_sumar = 1
+
+                if dia_semana == 5:
+                    dias_a_sumar = 2
+                elif dia_semana == 6:
+                    dias_a_sumar = 1
+
+                fecha_nueva_base = fecha_origen + timedelta(days=dias_a_sumar)
+
+                hora_aleatoria = random.randint(8, 18)
+                minuto_aleatorio = random.choice([0, 15, 30, 45])
+                
+                fecha_reprogramada = fecha_nueva_base.replace(
+                    hour=hora_aleatoria, 
+                    minute=minuto_aleatorio, 
+                    second=0, 
+                    microsecond=0
+                )
+
+                nueva_visita_reprogramada = Visita(
+                    cliente_id=visita_db.cliente_id,
+                    vendedor_id=visita_db.vendedor_id,
+                    fecha_visita_programada=fecha_reprogramada,
+                    estado="PENDIENTE"
+                )
+                
+                self.db.add(nueva_visita_reprogramada)
+                logger.info(f"Visita {visita_id} cancelada. Reprogramada para: {fecha_reprogramada}")
+
             self.db.commit()
             self.db.refresh(visita_db)
 
-            logger.info(f"Visita {visita_id} actualizada. Campos: {list(update_data.keys())}")
             return await self.get_visita_detalle_por_id(visita_id)
 
         except HTTPException as he:

--- a/src/visitas/services/visita_service.py
+++ b/src/visitas/services/visita_service.py
@@ -291,7 +291,7 @@ class VisitaService:
             if nuevo_estado:
                 estado_actual = visita_db.estado
                 
-                if estado_actual in ("TOMADA", "CANCELADA"):
+                if estado_actual in ("REALIZADA", "CANCELADA"):
                     
                     if nuevo_estado != estado_actual:
                         logger.warning(

--- a/src/visitas/tests/test_visita_router.py
+++ b/src/visitas/tests/test_visita_router.py
@@ -95,14 +95,14 @@ class TestVisitaRouter:
     async def test_actualizar_visita_endpoint(self, client: TestClient, mock_visita_service: Mock):
         """Test: Endpoint PUT /api/visitas/{visita_id} (async) - Éxito"""
         visita_id = uuid4()
-        payload = {"estado": "TOMADA", "detalle": "Visita completada"}
+        payload = {"estado": "REALIZADA", "detalle": "Visita completada"}
         
         mock_response_data = {
             "id": str(visita_id),
             "cliente_id": str(uuid4()),
             "vendedor_id": str(uuid4()),
             "fecha_visita_programada": datetime.now().isoformat(),
-            "estado": "TOMADA",
+            "estado": "REALIZADA",
             "detalle": "Visita completada",
             "created_at": datetime.now().isoformat(),
             "nombre_institucion": "Institución",
@@ -113,7 +113,7 @@ class TestVisitaRouter:
         response = client.put(f"/api/visitas/{visita_id}", json=payload)
         
         assert response.status_code == HTTPStatus.OK
-        assert response.json()["estado"] == "TOMADA"
+        assert response.json()["estado"] == "REALIZADA"
         mock_visita_service.actualizar_visita.assert_called_once_with(
             visita_id,
             ActualizarVisitaSchema(**payload)
@@ -178,5 +178,5 @@ class TestVisitaRouter:
         response = client.put(f"/api/visitas/{visita_id}", json=payload)
         
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-        assert "Input should be 'PENDIENTE', 'TOMADA' or 'CANCELADA'" in response.text
+        assert "Input should be 'PENDIENTE', 'REALIZADA' or 'CANCELADA'" in response.text
         mock_visita_service.actualizar_visita.assert_not_called()

--- a/src/visitas/tests/test_visita_router.py
+++ b/src/visitas/tests/test_visita_router.py
@@ -1,5 +1,3 @@
-# src/visitas/tests/test_visita_router.py
-
 import pytest
 from unittest.mock import Mock, AsyncMock
 from fastapi.testclient import TestClient
@@ -9,7 +7,15 @@ from datetime import datetime, date
 
 from fastapi import HTTPException 
 
-from schemas.visita_schema import CrearRutaVisitaSchema, ActualizarVisitaSchema
+from schemas.visita_schema import (
+    CrearRutaVisitaSchema, 
+    ActualizarVisitaSchema,
+    VisitaDetalleResponseSchema, 
+    RutaVisitaItemSchema,
+    NotaVisitaAnteriorSchema,
+    ProductoPreferidoSchema
+)
+from typing import List 
 
 pytestmark = pytest.mark.asyncio
 
@@ -46,14 +52,14 @@ class TestVisitaRouter:
         fecha = "2025-10-30"
         
         mock_response_data = [
-            {
-                "id": str(uuid4()),
-                "cliente_id": str(uuid4()),
-                "nombre": "Cliente Test",
-                "direccion": "Calle Falsa 123",
-                "hora_de_la_cita": "10:00",
-                "estado": "PENDIENTE"
-            }
+            RutaVisitaItemSchema(
+                id=uuid4(),
+                cliente_id=uuid4(),
+                nombre="Cliente Test",
+                direccion="Calle Falsa 123",
+                hora_de_la_cita="10:00",
+                estado="PENDIENTE"
+            )
         ]
         mock_visita_service.get_rutas_por_fecha_y_vendedor.return_value = mock_response_data
         
@@ -63,9 +69,12 @@ class TestVisitaRouter:
         data = response.json()
         assert len(data) == 1
         assert data[0]["nombre"] == "Cliente Test"
+        
         mock_visita_service.get_rutas_por_fecha_y_vendedor.assert_called_once_with(
-            date(2025, 10, 30), 
-            vendedor_id
+            fecha=date(2025, 10, 30),
+            vendedor_id=vendedor_id,
+            lat_actual=None,
+            lon_actual=None
         )
 
     @pytest.mark.asyncio
@@ -73,23 +82,30 @@ class TestVisitaRouter:
         """Test: Endpoint GET /api/visitas/{visita_id} (async) - Éxito"""
         visita_id = uuid4()
         
-        mock_response_data = {
-            "id": str(visita_id),
-            "cliente_id": str(uuid4()),
-            "vendedor_id": str(uuid4()),
-            "fecha_visita_programada": datetime.now().isoformat(),
-            "estado": "PENDIENTE",
-            "created_at": datetime.now().isoformat(),
-            "nombre_institucion": "Institución Detalle",
-            "direccion": "Av. Siempre Viva 742"
-        }
+        mock_response_data = VisitaDetalleResponseSchema(
+            id=visita_id,
+            cliente_id=uuid4(),
+            vendedor_id=uuid4(),
+            fecha_visita_programada=datetime.now(),
+            estado="PENDIENTE",
+            created_at=datetime.now(),
+            nombre_institucion="Institución Detalle",
+            direccion="Av. Siempre Viva 742",
+            notas_visitas_anteriores=[],
+            productos_preferidos=[]
+        )
         mock_visita_service.get_visita_detalle_por_id.return_value = mock_response_data
         
         response = client.get(f"/api/visitas/{visita_id}")
         
         assert response.status_code == HTTPStatus.OK
         assert response.json()["nombre_institucion"] == "Institución Detalle"
-        mock_visita_service.get_visita_detalle_por_id.assert_called_once_with(visita_id)
+        
+        mock_visita_service.get_visita_detalle_por_id.assert_called_once_with(
+            visita_id,         
+            lat_actual=None,
+            lon_actual=None
+        )
 
     @pytest.mark.asyncio
     async def test_actualizar_visita_endpoint(self, client: TestClient, mock_visita_service: Mock):
@@ -97,17 +113,20 @@ class TestVisitaRouter:
         visita_id = uuid4()
         payload = {"estado": "REALIZADA", "detalle": "Visita completada"}
         
-        mock_response_data = {
-            "id": str(visita_id),
-            "cliente_id": str(uuid4()),
-            "vendedor_id": str(uuid4()),
-            "fecha_visita_programada": datetime.now().isoformat(),
-            "estado": "REALIZADA",
-            "detalle": "Visita completada",
-            "created_at": datetime.now().isoformat(),
-            "nombre_institucion": "Institución",
-            "direccion": "Dirección"
-        }
+        mock_response_data = VisitaDetalleResponseSchema(
+            id=visita_id,
+            cliente_id=uuid4(),
+            vendedor_id=uuid4(),
+            fecha_visita_programada=datetime.now(),
+            estado="REALIZADA",
+            detalle="Visita completada",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            nombre_institucion="Institución",
+            direccion="Dirección",
+            notas_visitas_anteriores=[],
+            productos_preferidos=[]
+        )
         mock_visita_service.actualizar_visita.return_value = mock_response_data
         
         response = client.put(f"/api/visitas/{visita_id}", json=payload)
@@ -174,7 +193,7 @@ class TestVisitaRouter:
         """Test: Endpoint PUT /{visita_id} - Falla 422 si el estado en el body es inválido"""
         visita_id = uuid4()
         
-        payload = {"estado": "REALIZADA"}
+        payload = {"estado": "ESTADO_INVALIDO"}
         response = client.put(f"/api/visitas/{visita_id}", json=payload)
         
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/src/visitas/tests/test_visita_schema.py
+++ b/src/visitas/tests/test_visita_schema.py
@@ -1,5 +1,3 @@
-# src/visitas/tests/test_visita_schemas.py
-
 import pytest
 from pydantic import ValidationError
 from uuid import uuid4
@@ -10,7 +8,9 @@ from schemas.visita_schema import (
     ActualizarVisitaSchema,
     RutaVisitaItemSchema,
     VisitaDetalleResponseSchema,
-    EstadoVisitaEnum
+    EstadoVisitaEnum,
+    NotaVisitaAnteriorSchema, 
+    ProductoPreferidoSchema  
 )
 
 class TestRequestSchemas:
@@ -42,7 +42,7 @@ class TestRequestSchemas:
     def test_actualizar_visita_schema_estado_invalido(self):
         """Test: Falla si el estado no está en el Enum"""
         with pytest.raises(ValidationError):
-            ActualizarVisitaSchema(estado="REALIZADA")
+            ActualizarVisitaSchema(estado="ESTADO_INVALIDO")
 
     def test_actualizar_visita_schema_campos_opcionales(self):
         """Test: Todos los campos son opcionales"""
@@ -95,11 +95,15 @@ class TestResponseSchemas:
             "estado": "PENDIENTE",
             "created_at": datetime.now(),
             "nombre_institucion": "Institución Test",
-            "direccion": "Av. Siempre Viva 742"
+            "direccion": "Av. Siempre Viva 742",
+            "notas_visitas_anteriores": [],
+            "productos_preferidos": [],
+            "tiempo_desplazamiento": "15 min"
         }
         schema = VisitaDetalleResponseSchema(**data)
         assert schema.nombre_institucion == "Institución Test"
         assert schema.estado == "PENDIENTE"
+        assert schema.tiempo_desplazamiento == "15 min"
 
     
     def test_ruta_visita_item_schema_campos_nulos(self):

--- a/src/visitas/tests/test_visita_schema.py
+++ b/src/visitas/tests/test_visita_schema.py
@@ -32,11 +32,11 @@ class TestRequestSchemas:
     def test_actualizar_visita_schema_valid(self):
         """Test: Creación válida de schema de actualizar visita"""
         data = {
-            "estado": "TOMADA",
+            "estado": "REALIZADA",
             "detalle": "Visita completada exitosamente."
         }
         schema = ActualizarVisitaSchema(**data)
-        assert schema.estado == EstadoVisitaEnum.TOMADA
+        assert schema.estado == EstadoVisitaEnum.REALIZADA
         assert schema.detalle == "Visita completada exitosamente."
 
     def test_actualizar_visita_schema_estado_invalido(self):
@@ -110,7 +110,7 @@ class TestResponseSchemas:
             "nombre": "Cliente Sin Dirección",
             "direccion": None, 
             "hora_de_la_cita": "10:00",
-            "estado": "TOMADA"
+            "estado": "REALIZADA"
         }
         schema = RutaVisitaItemSchema(**data)
         assert schema.nombre == "Cliente Sin Dirección"

--- a/src/visitas/tests/test_visita_service.py
+++ b/src/visitas/tests/test_visita_service.py
@@ -144,7 +144,7 @@ class TestVisitaService:
     async def test_actualizar_visita_not_found(self, service: VisitaService, mock_db: Mock):
         """Test: Actualizar visita falla si no se encuentra"""
         visita_id = uuid4()
-        data = ActualizarVisitaSchema(estado="TOMADA")
+        data = ActualizarVisitaSchema(estado="REALIZADA")
         
         mock_db.query.return_value.filter.return_value.first.return_value = None
 
@@ -153,7 +153,7 @@ class TestVisitaService:
         assert e.value.status_code == HTTPStatus.NOT_FOUND
 
     async def test_actualizar_visita_transicion_invalida(self, service: VisitaService, mock_db: Mock):
-        """Test: Falla al intentar cambiar estado de visita 'TOMADA'"""
+        """Test: Falla al intentar cambiar estado de visita 'REALIZADA'"""
         visita_id = uuid4()
         data = ActualizarVisitaSchema(estado="PENDIENTE") # Intentar regresar a PENDIENTE
 
@@ -167,7 +167,7 @@ class TestVisitaService:
             fecha_visita_programada=dummy_fecha
         )
         mock_visita_db.id = visita_id
-        mock_visita_db.estado = "TOMADA" # Asigna el estado actual
+        mock_visita_db.estado = "REALIZADA" # Asigna el estado actual
         
         mock_db.query.return_value.filter.return_value.first.return_value = mock_visita_db
         

--- a/src/visitas/tests/test_visita_service.py
+++ b/src/visitas/tests/test_visita_service.py
@@ -1,5 +1,3 @@
-# src/visitas/tests/test_visita_service.py
-
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
 from sqlalchemy.orm import Session
@@ -11,7 +9,7 @@ from http import HTTPStatus
 
 from services.visita_service import VisitaService
 from db.visita import Visita
-from schemas.visita_schema import CrearRutaVisitaSchema, ActualizarVisitaSchema
+from schemas.visita_schema import CrearRutaVisitaSchema, ActualizarVisitaSchema, VisitaDetalleResponseSchema
 from fastapi import HTTPException
 
 pytestmark = pytest.mark.asyncio
@@ -33,6 +31,7 @@ class TestVisitaService:
             mock_redis = Mock()
             mock_get_redis.return_value = mock_redis
             service_instance = VisitaService(db=mock_db)
+            service_instance.google_maps_api_key = "fake-key-para-tests"
             yield service_instance
 
     @patch("services.visita_service.httpx.AsyncClient")
@@ -123,23 +122,46 @@ class TestVisitaService:
         mock_visita_db.id = uuid4()
         mock_visita_db.estado = "PENDIENTE"
         
-        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [mock_visita_db]
+        mock_query_pendiente = Mock()
+        mock_query_pendiente.all.return_value = [mock_visita_db]
+        
+        mock_query_otras = Mock()
+        mock_query_otras.order_by.return_value.all.return_value = [] 
+        
+        def query_side_effect(*args):
+            mock_filter = Mock()
+            mock_filter.all.return_value = mock_query_pendiente.all.return_value
+            mock_filter.order_by.return_value.all.return_value = mock_query_otras.order_by.return_value.all.return_value
+            return mock_filter
+
+        mock_db.query.return_value.filter.side_effect = query_side_effect
 
         mock_cliente_data = [{
             "id": str(cliente_id_1), 
             "nombre": "Cliente Test",
-            "address": "Calle Falsa 123"
+            "address": "7.1,-73.1,Calle Falsa 123"
         }]
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
-        mock_response = Mock(status_code=HTTPStatus.OK)
-        mock_response.json.return_value = mock_cliente_data
-        mock_async_client.post.return_value = mock_response
+        
+        mock_response_clientes = Mock(status_code=HTTPStatus.OK)
+        mock_response_clientes.json.return_value = mock_cliente_data
+        mock_async_client.post.return_value = mock_response_clientes
 
-        resultados = await service.get_rutas_por_fecha_y_vendedor(test_fecha, test_vendedor_id)
+        mock_gmaps_response = Mock(status_code=HTTPStatus.OK)
+        mock_gmaps_response.json.return_value = {
+            "status": "OK",
+            "routes": [{
+                "waypoint_order": [0],
+                "legs": [{"duration": {"text": "15 min"}}]
+            }]
+        }
+        mock_async_client.get.return_value = mock_gmaps_response
+
+        resultados = await service.get_rutas_por_fecha_y_vendedor(test_fecha, test_vendedor_id, 7.0, -73.0)
 
         assert len(resultados) == 1
         assert resultados[0].nombre == "Cliente Test"
-        assert resultados[0].hora_de_la_cita == "09:30"
+        assert resultados[0].hora_de_la_cita == "15 min"
 
     async def test_actualizar_visita_not_found(self, service: VisitaService, mock_db: Mock):
         """Test: Actualizar visita falla si no se encuentra"""
@@ -152,7 +174,13 @@ class TestVisitaService:
             await service.actualizar_visita(visita_id, data)
         assert e.value.status_code == HTTPStatus.NOT_FOUND
 
-    async def test_actualizar_visita_transicion_invalida(self, service: VisitaService, mock_db: Mock):
+    @patch("services.visita_service.VisitaService._get_cliente_data", new_callable=AsyncMock)
+    @patch("services.visita_service.VisitaService._get_top_products_data", new_callable=AsyncMock)
+    @patch("services.visita_service.VisitaService._get_user_contact_for_client", new_callable=AsyncMock)
+    async def test_actualizar_visita_transicion_invalida(
+        self, mock_get_contact: Mock, mock_get_products: Mock, mock_get_cliente: Mock, 
+        service: VisitaService, mock_db: Mock
+    ):
         """Test: Falla al intentar cambiar estado de visita 'REALIZADA'"""
         visita_id = uuid4()
         data = ActualizarVisitaSchema(estado="PENDIENTE") # Intentar regresar a PENDIENTE
@@ -235,7 +263,18 @@ class TestVisitaService:
         test_fecha = date(2025, 1, 1)
         test_vendedor_id = uuid4()
         
-        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+        mock_query_pendiente = Mock()
+        mock_query_pendiente.all.return_value = []
+        mock_query_otras = Mock()
+        mock_query_otras.order_by.return_value.all.return_value = []
+        
+        def query_side_effect(*args):
+            mock_filter = Mock()
+            mock_filter.all.return_value = mock_query_pendiente.all.return_value
+            mock_filter.order_by.return_value.all.return_value = mock_query_otras.order_by.return_value.all.return_value
+            return mock_filter
+            
+        mock_db.query.return_value.filter.side_effect = query_side_effect
 
         resultados = await service.get_rutas_por_fecha_y_vendedor(test_fecha, test_vendedor_id)
 
@@ -257,32 +296,40 @@ class TestVisitaService:
         visita_id = uuid4()
         cliente_id = uuid4()
 
-        # 1. Mockear BBDD (la visita SÍ existe)
         dummy_vendedor_id = uuid4()
         dummy_fecha = datetime.now()
-        mock_visita_db = Visita(
-            cliente_id=cliente_id,
-            vendedor_id=dummy_vendedor_id,
-            fecha_visita_programada=dummy_fecha
-        )
+        mock_visita_db = Visita(cliente_id=cliente_id, vendedor_id=dummy_vendedor_id, fecha_visita_programada=dummy_fecha)
         mock_visita_db.id = visita_id
         mock_visita_db.estado = "PENDIENTE"
         mock_visita_db.to_dict = lambda: {
             "id": visita_id, "cliente_id": cliente_id, "vendedor_id": dummy_vendedor_id,
-            "fecha_visita_programada": dummy_fecha, "estado": "PENDIENTE",
-            "created_at": dummy_fecha, "updated_at": None, "cliente_contacto": None,
-            "detalle": None, "evidencia": None, "inicio": None, "fin": None
+            "fecha_visita_programada": dummy_fecha, "estado": "PENDIENTE", "created_at": dummy_fecha, 
+            "updated_at": None, "cliente_contacto": None, "detalle": None, "evidencia": None, "inicio": None, "fin": None
         }
         mock_db.query.return_value.filter.return_value.first.return_value = mock_visita_db
+        
+        mock_db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
 
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_async_client.post.side_effect = httpx.RequestError("Error de red simulado")
         
+        mock_response_ok = Mock(status_code=HTTPStatus.OK)
+        mock_response_ok.json.return_value = {"data": []} 
+        mock_response_notfound = Mock(status_code=HTTPStatus.NOT_FOUND) 
+        
+        mock_async_client.get.side_effect = [
+            mock_response_ok,       
+            mock_response_notfound, 
+        ]
+    
         resultado = await service.get_visita_detalle_por_id(visita_id)
         
         assert resultado.id == visita_id
         assert resultado.nombre_institucion == "Cliente no disponible"
         assert resultado.direccion == "Dirección no disponible"
+        assert resultado.productos_preferidos == []
+        assert resultado.notas_visitas_anteriores == []
+        assert resultado.cliente_contacto is None
 
     async def test_actualizar_visita_payload_vacio(self, service: VisitaService, mock_db: Mock):
         """Test: Falla 400 si se intenta actualizar sin datos"""

--- a/src/visitas/tests/test_visita_service.py
+++ b/src/visitas/tests/test_visita_service.py
@@ -9,10 +9,55 @@ from http import HTTPStatus
 
 from services.visita_service import VisitaService
 from db.visita import Visita
-from schemas.visita_schema import CrearRutaVisitaSchema, ActualizarVisitaSchema, VisitaDetalleResponseSchema
+from schemas.visita_schema import (
+    CrearRutaVisitaSchema, 
+    ActualizarVisitaSchema, 
+    VisitaDetalleResponseSchema
+)
 from fastapi import HTTPException
 
 pytestmark = pytest.mark.asyncio
+
+def create_mock_visita(visita_id: uuid4, cliente_id, vendedor_id, estado="PENDIENTE"):
+    """
+    Crea un objeto Visita mockeado.
+    AHORA ACEPTA visita_id COMO ARGUMENTO.
+    """
+    fecha = datetime.now()
+    mock_visita = Visita(
+        cliente_id=cliente_id,
+        vendedor_id=vendedor_id,
+        fecha_visita_programada=fecha
+    )
+    mock_visita.id = visita_id 
+    mock_visita.estado = estado
+    mock_visita.to_dict = lambda: {
+        "id": visita_id, 
+        "cliente_id": cliente_id, "vendedor_id": vendedor_id,
+        "fecha_visita_programada": fecha, "estado": estado, "created_at": fecha, 
+        "updated_at": None, "cliente_contacto": None, "detalle": None, 
+        "evidencia": None, "inicio": None, "fin": None
+    }
+    return mock_visita
+
+def mock_db_query_side_effect(pendientes_list, otras_list):
+    """Crea un side_effect para simular las dos consultas de get_rutas"""
+    def query_side_effect(*args): 
+        mock_filter = Mock()
+        mock_filter.all.return_value = pendientes_list
+        mock_filter.order_by.return_value.all.return_value = otras_list
+        return mock_filter
+    return query_side_effect
+
+def mock_http_responses(mock_async_client, post_response=None, get_responses=None):
+    """Configura las respuestas mock para httpx.AsyncClient"""
+    if post_response:
+        mock_async_client.post.return_value = post_response
+    
+    if get_responses:
+        mock_async_client.get.side_effect = get_responses
+
+# ---------------------------------
 
 class TestVisitaService:
 
@@ -25,7 +70,7 @@ class TestVisitaService:
     def service(self, mock_db: Mock):
         """
         Fixture del servicio. Parcheamos 'get_redis_client' 
-        que es llamado DENTRO del __init__.
+        y seteamos la API key.
         """
         with patch('services.visita_service.get_redis_client') as mock_get_redis:
             mock_redis = Mock()
@@ -39,27 +84,21 @@ class TestVisitaService:
         """Test: _get_cliente_data exitoso"""
         cliente_id = str(uuid4())
         mock_cliente_data = [{"id": cliente_id, "id_vendedor": str(uuid4())}]
-
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_response = Mock(status_code=HTTPStatus.OK)
         mock_response.json.return_value = mock_cliente_data
         mock_async_client.post.return_value = mock_response
-
         data = await service._get_cliente_data(cliente_id)
-        
         assert data == mock_cliente_data[0]
-        mock_async_client.post.assert_called_once()
 
     @patch("services.visita_service.httpx.AsyncClient")
     async def test_get_cliente_data_not_found(self, mock_http_client: Mock, service: VisitaService):
         """Test: _get_cliente_data falla si el cliente no existe"""
         cliente_id = str(uuid4())
-        
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_response = Mock(status_code=HTTPStatus.OK)
         mock_response.json.return_value = [] 
         mock_async_client.post.return_value = mock_response
-
         with pytest.raises(HTTPException) as e:
             await service._get_cliente_data(cliente_id)
         assert e.value.status_code == HTTPStatus.NOT_FOUND
@@ -70,16 +109,12 @@ class TestVisitaService:
         cliente_id = uuid4()
         vendedor_id = uuid4()
         data = CrearRutaVisitaSchema(cliente_id=cliente_id)
-        
         mock_cliente_data = [{"id": str(cliente_id), "id_vendedor": str(vendedor_id)}]
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_response = Mock(status_code=HTTPStatus.OK)
         mock_response.json.return_value = mock_cliente_data
         mock_async_client.post.return_value = mock_response
-
-        mock_visita = Mock(spec=Visita)
-        mock_visita.to_dict.return_value = {"id": str(uuid4()), "cliente_id": cliente_id}
-        mock_db.refresh.side_effect = lambda x: setattr(x, 'to_dict', mock_visita.to_dict)
+        mock_db.refresh.side_effect = lambda x: setattr(x, 'to_dict', lambda: {"id": str(uuid4()), "cliente_id": cliente_id})
 
         resultado = await service.crear_ruta_visita(data)
         
@@ -92,13 +127,11 @@ class TestVisitaService:
         """Test: Falla si el cliente no tiene vendedor asignado"""
         cliente_id = uuid4()
         data = CrearRutaVisitaSchema(cliente_id=cliente_id)
-        
-        mock_cliente_data = [{"id": str(cliente_id), "id_vendedor": None}] # Sin vendedor
+        mock_cliente_data = [{"id": str(cliente_id), "id_vendedor": None}]
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_response = Mock(status_code=HTTPStatus.OK)
         mock_response.json.return_value = mock_cliente_data
         mock_async_client.post.return_value = mock_response
-
         with pytest.raises(HTTPException) as e:
             await service.crear_ruta_visita(data)
         assert e.value.status_code == HTTPStatus.BAD_REQUEST
@@ -107,54 +140,30 @@ class TestVisitaService:
 
     @patch("services.visita_service.httpx.AsyncClient")
     async def test_get_rutas_por_fecha_y_vendedor_success(self, mock_http_client: Mock, service: VisitaService, mock_db: Mock):
-        """Test: Obtener rutas del día exitosamente"""
+        """Test: Obtener rutas del día exitosamente (optimizadas)"""
         test_fecha = date(2025, 1, 1)
         test_vendedor_id = uuid4()
         cliente_id_1 = uuid4()
+        mock_visita_db = create_mock_visita(uuid4(), cliente_id_1, test_vendedor_id, "PENDIENTE")
         
-        fecha_programada = datetime(2025, 1, 1, 9, 30)
-        
-        mock_visita_db = Visita(
-            cliente_id=cliente_id_1,
-            vendedor_id=test_vendedor_id,
-            fecha_visita_programada=fecha_programada
+        # Mock de BD: 1 pendiente, 0 otras
+        mock_db.query.return_value.filter.side_effect = mock_db_query_side_effect(
+            pendientes_list=[mock_visita_db],
+            otras_list=[]
         )
-        mock_visita_db.id = uuid4()
-        mock_visita_db.estado = "PENDIENTE"
-        
-        mock_query_pendiente = Mock()
-        mock_query_pendiente.all.return_value = [mock_visita_db]
-        
-        mock_query_otras = Mock()
-        mock_query_otras.order_by.return_value.all.return_value = [] 
-        
-        def query_side_effect(*args):
-            mock_filter = Mock()
-            mock_filter.all.return_value = mock_query_pendiente.all.return_value
-            mock_filter.order_by.return_value.all.return_value = mock_query_otras.order_by.return_value.all.return_value
-            return mock_filter
 
-        mock_db.query.return_value.filter.side_effect = query_side_effect
-
-        mock_cliente_data = [{
-            "id": str(cliente_id_1), 
-            "nombre": "Cliente Test",
-            "address": "7.1,-73.1,Calle Falsa 123"
-        }]
+        mock_cliente_data = [{"id": str(cliente_id_1), "nombre": "Cliente Test", "address": "7.1,-73.1,Calle Falsa 123"}]
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         
         mock_response_clientes = Mock(status_code=HTTPStatus.OK)
         mock_response_clientes.json.return_value = mock_cliente_data
-        mock_async_client.post.return_value = mock_response_clientes
-
+        
         mock_gmaps_response = Mock(status_code=HTTPStatus.OK)
         mock_gmaps_response.json.return_value = {
             "status": "OK",
-            "routes": [{
-                "waypoint_order": [0],
-                "legs": [{"duration": {"text": "15 min"}}]
-            }]
+            "routes": [{"waypoint_order": [0], "legs": [{"duration": {"text": "15 min"}}]}]
         }
+        mock_async_client.post.return_value = mock_response_clientes
         mock_async_client.get.return_value = mock_gmaps_response
 
         resultados = await service.get_rutas_por_fecha_y_vendedor(test_fecha, test_vendedor_id, 7.0, -73.0)
@@ -163,13 +172,59 @@ class TestVisitaService:
         assert resultados[0].nombre == "Cliente Test"
         assert resultados[0].hora_de_la_cita == "15 min"
 
+    @patch("services.visita_service.httpx.AsyncClient")
+    async def test_get_rutas_google_maps_falla(self, mock_http_client: Mock, service: VisitaService, mock_db: Mock):
+        """Test: Devuelve ruta sin optimizar si Google Maps falla"""
+        test_fecha = date(2025, 1, 1)
+        test_vendedor_id = uuid4()
+        cliente_id_1 = uuid4()
+        mock_visita_db = create_mock_visita(uuid4(), cliente_id_1, test_vendedor_id, "PENDIENTE")
+
+        mock_db.query.return_value.filter.side_effect = mock_db_query_side_effect([mock_visita_db], [])
+        
+        mock_cliente_data = [{"id": str(cliente_id_1), "nombre": "Cliente Test", "address": "7.1,-73.1,Calle Falsa 123"}]
+        mock_async_client = mock_http_client.return_value.__aenter__.return_value
+        
+        mock_response_clientes = Mock(status_code=HTTPStatus.OK)
+        mock_response_clientes.json.return_value = mock_cliente_data
+        mock_async_client.post.return_value = mock_response_clientes
+
+        mock_gmaps_response = Mock(status_code=HTTPStatus.OK)
+        mock_gmaps_response.json.return_value = {"status": "REQUEST_DENIED"}
+        mock_async_client.get.return_value = mock_gmaps_response
+
+        resultados = await service.get_rutas_por_fecha_y_vendedor(test_fecha, test_vendedor_id, 7.0, -73.0)
+        
+        assert len(resultados) == 1
+        assert resultados[0].hora_de_la_cita == "Sin calcular"
+
+    @patch("services.visita_service.httpx.AsyncClient")
+    async def test_get_rutas_visitas_sin_coordenadas(self, mock_http_client: Mock, service: VisitaService, mock_db: Mock):
+        """Test: Devuelve ruta sin optimizar si las visitas no tienen coordenadas (NA,NA)"""
+        test_fecha = date(2025, 1, 1)
+        test_vendedor_id = uuid4()
+        cliente_id_1 = uuid4()
+        mock_visita_db = create_mock_visita(uuid4(), cliente_id_1, test_vendedor_id, "PENDIENTE")
+
+        mock_db.query.return_value.filter.side_effect = mock_db_query_side_effect([mock_visita_db], [])
+        
+        mock_cliente_data = [{"id": str(cliente_id_1), "nombre": "Cliente Test", "address": "NA,NA,Calle Falsa 123"}]
+        mock_async_client = mock_http_client.return_value.__aenter__.return_value
+        
+        mock_response_clientes = Mock(status_code=HTTPStatus.OK)
+        mock_response_clientes.json.return_value = mock_cliente_data
+        mock_async_client.post.return_value = mock_response_clientes
+
+        resultados = await service.get_rutas_por_fecha_y_vendedor(test_fecha, test_vendedor_id, 7.0, -73.0)
+        
+        mock_async_client.get.assert_not_called()
+        assert len(resultados) == 1
+        assert resultados[0].hora_de_la_cita == "Sin calcular"
+
     async def test_actualizar_visita_not_found(self, service: VisitaService, mock_db: Mock):
-        """Test: Actualizar visita falla si no se encuentra"""
         visita_id = uuid4()
         data = ActualizarVisitaSchema(estado="REALIZADA")
-        
         mock_db.query.return_value.filter.return_value.first.return_value = None
-
         with pytest.raises(HTTPException) as e:
             await service.actualizar_visita(visita_id, data)
         assert e.value.status_code == HTTPStatus.NOT_FOUND
@@ -177,25 +232,15 @@ class TestVisitaService:
     @patch("services.visita_service.VisitaService._get_cliente_data", new_callable=AsyncMock)
     @patch("services.visita_service.VisitaService._get_top_products_data", new_callable=AsyncMock)
     @patch("services.visita_service.VisitaService._get_user_contact_for_client", new_callable=AsyncMock)
+    @patch("services.visita_service.VisitaService._get_single_route_travel_time", new_callable=AsyncMock)
     async def test_actualizar_visita_transicion_invalida(
-        self, mock_get_contact: Mock, mock_get_products: Mock, mock_get_cliente: Mock, 
+        self, mock_get_time: Mock, mock_get_contact: Mock, mock_get_products: Mock, mock_get_cliente: Mock, 
         service: VisitaService, mock_db: Mock
     ):
         """Test: Falla al intentar cambiar estado de visita 'REALIZADA'"""
         visita_id = uuid4()
-        data = ActualizarVisitaSchema(estado="PENDIENTE") # Intentar regresar a PENDIENTE
-
-        dummy_cliente_id = uuid4()
-        dummy_vendedor_id = uuid4()
-        dummy_fecha = datetime.now()
-
-        mock_visita_db = Visita(
-            cliente_id=dummy_cliente_id,
-            vendedor_id=dummy_vendedor_id,
-            fecha_visita_programada=dummy_fecha
-        )
-        mock_visita_db.id = visita_id
-        mock_visita_db.estado = "REALIZADA" # Asigna el estado actual
+        data = ActualizarVisitaSchema(estado="PENDIENTE")
+        mock_visita_db = create_mock_visita(visita_id, uuid4(), uuid4(), "REALIZADA")
         
         mock_db.query.return_value.filter.return_value.first.return_value = mock_visita_db
         
@@ -207,50 +252,37 @@ class TestVisitaService:
 
     @patch("services.visita_service.httpx.AsyncClient")
     async def test_get_cliente_data_request_error(self, mock_http_client: Mock, service: VisitaService):
-        """Test: _get_cliente_data falla si httpx lanza RequestError"""
         cliente_id = str(uuid4())
-        
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_async_client.post.side_effect = httpx.RequestError("Error de red simulado")
-
         with pytest.raises(HTTPException) as e:
             await service._get_cliente_data(cliente_id)
         assert e.value.status_code == HTTPStatus.SERVICE_UNAVAILABLE
-        assert "No se pudo conectar" in e.value.detail
 
     @patch("services.visita_service.httpx.AsyncClient")
     async def test_crear_ruta_visita_vendedor_id_invalido(self, mock_http_client: Mock, service: VisitaService):
-        """Test: Falla 500 si el id_vendedor recibido del cliente no es un UUID"""
         cliente_id = uuid4()
         data = CrearRutaVisitaSchema(cliente_id=cliente_id)
-        
         mock_cliente_data = [{"id": str(cliente_id), "id_vendedor": "no-es-un-uuid"}]
-        
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_response = Mock(status_code=HTTPStatus.OK)
         mock_response.json.return_value = mock_cliente_data
         mock_async_client.post.return_value = mock_response
-
         with pytest.raises(HTTPException) as e:
             await service.crear_ruta_visita(data)
         assert e.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-        assert "ID del vendedor recibido" in e.value.detail
 
     @patch("services.visita_service.httpx.AsyncClient")
     async def test_crear_ruta_visita_db_integrity_error(self, mock_http_client: Mock, service: VisitaService, mock_db: Mock):
-        """Test: Falla 409 si la BBDD lanza un IntegrityError"""
         cliente_id = uuid4()
         vendedor_id = uuid4()
         data = CrearRutaVisitaSchema(cliente_id=cliente_id)
-        
         mock_cliente_data = [{"id": str(cliente_id), "id_vendedor": str(vendedor_id)}]
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_response = Mock(status_code=HTTPStatus.OK)
         mock_response.json.return_value = mock_cliente_data
         mock_async_client.post.return_value = mock_response
-
         mock_db.commit.side_effect = IntegrityError("Simulación de error", "params", "orig")
-        
         with pytest.raises(HTTPException) as e:
             await service.crear_ruta_visita(data)
         assert e.value.status_code == HTTPStatus.CONFLICT
@@ -263,18 +295,10 @@ class TestVisitaService:
         test_fecha = date(2025, 1, 1)
         test_vendedor_id = uuid4()
         
-        mock_query_pendiente = Mock()
-        mock_query_pendiente.all.return_value = []
-        mock_query_otras = Mock()
-        mock_query_otras.order_by.return_value.all.return_value = []
-        
-        def query_side_effect(*args):
-            mock_filter = Mock()
-            mock_filter.all.return_value = mock_query_pendiente.all.return_value
-            mock_filter.order_by.return_value.all.return_value = mock_query_otras.order_by.return_value.all.return_value
-            return mock_filter
-            
-        mock_db.query.return_value.filter.side_effect = query_side_effect
+        mock_db.query.return_value.filter.side_effect = mock_db_query_side_effect(
+            pendientes_list=[],
+            otras_list=[]
+        )
 
         resultados = await service.get_rutas_por_fecha_y_vendedor(test_fecha, test_vendedor_id)
 
@@ -282,30 +306,19 @@ class TestVisitaService:
         mock_http_client.assert_not_called()
 
     async def test_get_visita_detalle_por_id_not_found(self, service: VisitaService, mock_db: Mock):
-        """Test: get_visita_detalle_por_id falla 404 si no se encuentra"""
         visita_id = uuid4()
         mock_db.query.return_value.filter.return_value.first.return_value = None
-
         with pytest.raises(HTTPException) as e:
             await service.get_visita_detalle_por_id(visita_id)
         assert e.value.status_code == HTTPStatus.NOT_FOUND
 
     @patch("services.visita_service.httpx.AsyncClient")
     async def test_get_visita_detalle_cliente_service_falla(self, mock_http_client: Mock, service: VisitaService, mock_db: Mock):
-        """Test: get_visita_detalle_por_id devuelve datos por defecto si el servicio de cliente falla"""
+        """Test: get_visita_detalle_por_id devuelve datos por defecto si servicios externos fallan"""
         visita_id = uuid4()
         cliente_id = uuid4()
 
-        dummy_vendedor_id = uuid4()
-        dummy_fecha = datetime.now()
-        mock_visita_db = Visita(cliente_id=cliente_id, vendedor_id=dummy_vendedor_id, fecha_visita_programada=dummy_fecha)
-        mock_visita_db.id = visita_id
-        mock_visita_db.estado = "PENDIENTE"
-        mock_visita_db.to_dict = lambda: {
-            "id": visita_id, "cliente_id": cliente_id, "vendedor_id": dummy_vendedor_id,
-            "fecha_visita_programada": dummy_fecha, "estado": "PENDIENTE", "created_at": dummy_fecha, 
-            "updated_at": None, "cliente_contacto": None, "detalle": None, "evidencia": None, "inicio": None, "fin": None
-        }
+        mock_visita_db = create_mock_visita(visita_id, cliente_id, uuid4(), "PENDIENTE")
         mock_db.query.return_value.filter.return_value.first.return_value = mock_visita_db
         
         mock_db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
@@ -313,18 +326,18 @@ class TestVisitaService:
         mock_async_client = mock_http_client.return_value.__aenter__.return_value
         mock_async_client.post.side_effect = httpx.RequestError("Error de red simulado")
         
-        mock_response_ok = Mock(status_code=HTTPStatus.OK)
-        mock_response_ok.json.return_value = {"data": []} 
+        mock_response_ok_empty = Mock(status_code=HTTPStatus.OK)
+        mock_response_ok_empty.json.return_value = {"data": []} 
         mock_response_notfound = Mock(status_code=HTTPStatus.NOT_FOUND) 
         
         mock_async_client.get.side_effect = [
-            mock_response_ok,       
+            mock_response_ok_empty, 
             mock_response_notfound, 
         ]
     
         resultado = await service.get_visita_detalle_por_id(visita_id)
         
-        assert resultado.id == visita_id
+        assert resultado.id == visita_id 
         assert resultado.nombre_institucion == "Cliente no disponible"
         assert resultado.direccion == "Dirección no disponible"
         assert resultado.productos_preferidos == []
@@ -332,22 +345,60 @@ class TestVisitaService:
         assert resultado.cliente_contacto is None
 
     async def test_actualizar_visita_payload_vacio(self, service: VisitaService, mock_db: Mock):
-        """Test: Falla 400 si se intenta actualizar sin datos"""
         visita_id = uuid4()
         data = ActualizarVisitaSchema() 
 
-        dummy_cliente_id = uuid4()
-        dummy_vendedor_id = uuid4()
-        dummy_fecha = datetime.now()
-        mock_visita_db = Visita(
-            cliente_id=dummy_cliente_id,
-            vendedor_id=dummy_vendedor_id,
-            fecha_visita_programada=dummy_fecha
-        )
-        mock_visita_db.id = visita_id
+        mock_visita_db = create_mock_visita(visita_id, uuid4(), uuid4(), "PENDIENTE")
         mock_db.query.return_value.filter.return_value.first.return_value = mock_visita_db
 
         with pytest.raises(HTTPException) as e:
             await service.actualizar_visita(visita_id, data)
         assert e.value.status_code == HTTPStatus.BAD_REQUEST
         assert "No se proporcionaron datos" in e.value.detail
+
+    @patch("services.visita_service.VisitaService._get_cliente_data", new_callable=AsyncMock)
+    @patch("services.visita_service.VisitaService._get_top_products_data", new_callable=AsyncMock)
+    @patch("services.visita_service.VisitaService._get_user_contact_for_client", new_callable=AsyncMock)
+    @patch("services.visita_service.VisitaService._get_single_route_travel_time", new_callable=AsyncMock)
+    async def test_get_visita_detalle_calcula_tiempo_viaje(
+        self, mock_get_time: Mock, mock_get_contact: Mock, mock_get_products: Mock, mock_get_cliente: Mock, 
+        service: VisitaService, mock_db: Mock
+    ):
+        """Test: get_visita_detalle_por_id calcula el tiempo de viaje si se provee lat/lon"""
+        visita_id = uuid4()
+        cliente_id = uuid4()
+        mock_visita_db = create_mock_visita(visita_id, cliente_id, uuid4(), "PENDIENTE")
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_visita_db
+        
+        mock_get_cliente.return_value = {"nombre": "Cliente", "address": "7.1,-73.1,Calle"}
+        mock_db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+        mock_get_products.return_value = []
+        mock_get_contact.return_value = "Contacto Prueba"
+        
+        mock_get_time.return_value = "10 min"
+
+        resultado = await service.get_visita_detalle_por_id(visita_id, lat_actual=7.0, lon_actual=-73.0)
+
+        mock_get_time.assert_called_once_with("7.0,-73.0", "7.1,-73.1")
+        assert resultado.tiempo_desplazamiento == "10 min"
+        assert resultado.cliente_contacto == "Contacto Prueba"
+
+    @patch("services.visita_service.VisitaService.get_visita_detalle_por_id", new_callable=AsyncMock)
+    async def test_actualizar_visita_reprograma_al_cancelar(self, mock_get_detalle: Mock, service: VisitaService, mock_db: Mock):
+        """Test: actualizar_visita crea una nueva visita (reprograma) si el estado es CANCELADA"""
+        visita_id = uuid4()
+        data = ActualizarVisitaSchema(estado="CANCELADA", detalle="Prueba")
+        
+        mock_visita_db = create_mock_visita(visita_id, uuid4(), uuid4(), "PENDIENTE")
+        
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_visita_db
+        
+        mock_get_detalle.return_value = VisitaDetalleResponseSchema(**mock_visita_db.to_dict(), nombre_institucion="Test", direccion="Test")
+
+        await service.actualizar_visita(visita_id, data)
+        
+        assert mock_db.add.call_count == 2
+        mock_db.commit.assert_called_once()
+        segunda_llamada_args = mock_db.add.call_args_list[1].args
+        assert isinstance(segunda_llamada_args[0], Visita)
+        assert segunda_llamada_args[0].estado == "PENDIENTE"


### PR DESCRIPTION
Este PR refactoriza el módulo de visitas para cumplir con los nuevos requisitos de negocio. Se elimina la lógica de "horas aleatorias" y se reemplaza por un sistema de optimización de rutas en tiempo real basado en la ubicación del vendedor, consumiendo la API de Google Maps.

Cambios Implementados

**1. Endpoint POST /api/visitas/ (Crear Visita)**
- Modificado: La función crear_ruta_visita ya no asigna una hora aleatoria.
- Modificado: Ahora guarda la fecha_visita_programada a las 00:00:00 UTC.
- Nuevo: El schema CrearRutaVisitaSchema ahora acepta un campo opcional fecha_visita_programada: date. Si se provee, usa esa fecha; si no, usa la lógica de "hoy o próximo día hábil".

**2. Endpoint GET /api/visitas/rutas-del-dia (Ruta Optimizada)**

- Modificado: La firma del endpoint ahora acepta dos parámetros Query opcionales: lat_actual: float y lon_actual: float.
- Lógica Nueva: Si no se reciben lat/lon (o falta la API key), el endpoint devuelve todas las visitas del día (Pendientes, Realizadas, Canceladas) en un orden simple.

Si sí se reciben lat/lon:

- El servicio separa las visitas "PENDIENTES" de las "REALIZADAS/CANCELADAS".
- Extrae las coordenadas de las visitas pendientes (desde el campo direccion del cliente).
- Construye una llamada a la API de Google Maps Directions usando la ubicación del vendedor como origin y las coordenadas de las visitas como waypoints con optimize:true.
- Recibe la ruta optimizada de Google (el waypoint_order y los legs del viaje).
- Reordena la lista de visitas pendientes según la respuesta de Google.
- El campo hora_de_la_cita del schema se reutiliza para enviar el tiempo de viaje de cada tramo (ej: "15 min").
- La respuesta final es una lista que contiene [Ruta Optimizada] + [Visitas Completadas/Canceladas (con "N/A")].

**3. Endpoint GET /api/visitas/{visita_id} (Detalle)**

- Modificado: La firma del endpoint ahora también acepta lat_actual: float y lon_actual: float opcionales.
- Nueva Integración (Tiempo de Viaje): Si se reciben lat/lon, el servicio hace una llamada simple a Google Maps (A->B) para calcular el tiempo de viaje directo desde la ubicación del vendedor hasta esta visita en particular.
- El resultado se añade al schema de respuesta en el nuevo campo tiempo_desplazamiento.
- Nueva Integración (Productos Preferidos): Se añade el helper _get_top_products_data que llama al endpoint GET /api/ordenes/client-top-products del servicio de órdenes.
- La respuesta se añade al schema en el nuevo campo productos_preferidos.
- Nueva Integración (Contacto del Cliente): Se añade el helper _get_user_contact_for_client que llama al endpoint GET /api/auth/user-by-client/{cliente_id} del servicio de autenticación.
- El username resultante se usa para poblar el campo cliente_contacto de la respuesta.

**4. Endpoint PUT /api/visitas/{visita_id} (Actualizar Visita)**

- Modificado: Se mantiene la lógica de reprogramación automática. Si estado cambia a CANCELADA, se crea una nueva visita "PENDIENTE" para el siguiente día hábil (basado en la fecha de la visita original, no en datetime.now()).

**Pruebas (Tests)**

- Se actualizaron todos los tests (test_visita_router.py, test_visita_service.py) para reflejar las nuevas firmas de los métodos (con lat_actual=None, lon_actual=None).
- Se corrigieron los mocks de base de datos para simular las múltiples consultas (pendientes + otras) y evitar errores TypeError.
- Se añadieron tests para los nuevos casos borde (falla de Google Maps, visitas sin coordenadas).